### PR TITLE
feat: redesign factory dashboard to edit-in-place

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -52,4 +52,19 @@ jobs:
 
             Low-severity findings (style-only): create issues with type:chore and source:code-quality only.
 
-            Write summary to /tmp/summary.md and post to Factory Dashboard issue if it exists.
+            Write summary to /tmp/summary.md.
+
+            Post the summary as a sticky comment on the "[Factory Dashboard]" issue (find-or-create pattern):
+              MARKER="<!-- factory:code-quality -->"
+              DASHBOARD=$(gh issue list --repo ${{ github.repository }} --search "[Factory Dashboard]" --state open --json number --jq '.[0].number')
+              if [ -n "$DASHBOARD" ]; then
+                COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/$DASHBOARD/comments \
+                  --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+                echo "$MARKER" | cat - /tmp/summary.md > /tmp/summary-marked.md
+                if [ -n "$COMMENT_ID" ]; then
+                  gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
+                    -X PATCH -f body=@/tmp/summary-marked.md
+                else
+                  gh issue comment "$DASHBOARD" --repo ${{ github.repository }} --body-file /tmp/summary-marked.md
+                fi
+              fi

--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -53,8 +53,17 @@ jobs:
 
             After processing all findings, write a summary to /tmp/summary.md.
 
-            Post the summary as a comment on issue titled "[Factory Dashboard]" if it exists:
+            Post the summary as a sticky comment on the "[Factory Dashboard]" issue (find-or-create pattern):
+              MARKER="<!-- factory:dep-audit -->"
               DASHBOARD=$(gh issue list --repo ${{ github.repository }} --search "[Factory Dashboard]" --state open --json number --jq '.[0].number')
               if [ -n "$DASHBOARD" ]; then
-                gh issue comment "$DASHBOARD" --repo ${{ github.repository }} --body-file /tmp/summary.md
+                COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/$DASHBOARD/comments \
+                  --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+                echo "$MARKER" | cat - /tmp/summary.md > /tmp/summary-marked.md
+                if [ -n "$COMMENT_ID" ]; then
+                  gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
+                    -X PATCH -f body=@/tmp/summary-marked.md
+                else
+                  gh issue comment "$DASHBOARD" --repo ${{ github.repository }} --body-file /tmp/summary-marked.md
+                fi
               fi

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -52,4 +52,19 @@ jobs:
                - Apply labels with separate --add-label flags
             c. If matching issue exists, add a comment with updated findings.
 
-            Write summary to /tmp/summary.md and post to Factory Dashboard issue if it exists.
+            Write summary to /tmp/summary.md.
+
+            Post the summary as a sticky comment on the "[Factory Dashboard]" issue (find-or-create pattern):
+              MARKER="<!-- factory:docs-freshness -->"
+              DASHBOARD=$(gh issue list --repo ${{ github.repository }} --search "[Factory Dashboard]" --state open --json number --jq '.[0].number')
+              if [ -n "$DASHBOARD" ]; then
+                COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/$DASHBOARD/comments \
+                  --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+                echo "$MARKER" | cat - /tmp/summary.md > /tmp/summary-marked.md
+                if [ -n "$COMMENT_ID" ]; then
+                  gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
+                    -X PATCH -f body=@/tmp/summary-marked.md
+                else
+                  gh issue comment "$DASHBOARD" --repo ${{ github.repository }} --body-file /tmp/summary-marked.md
+                fi
+              fi

--- a/.github/workflows/factory-orchestrator.yml
+++ b/.github/workflows/factory-orchestrator.yml
@@ -99,7 +99,7 @@ jobs:
     name: Update Factory Dashboard
     runs-on: ubuntu-latest
     steps:
-      - name: Post status summary
+      - name: Edit dashboard issue body
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -125,11 +125,21 @@ jobs:
           AUTOFIX_2=$(gh issue list --repo "$REPO" --label "autofix:2" --state open --json number --jq 'length')
           AUTOFIX_3=$(gh issue list --repo "$REPO" --label "autofix:3" --state open --json number --jq 'length')
 
-          cat > /tmp/dashboard.md << EOF
-          ## Factory Status ($(date -u '+%Y-%m-%d %H:%M UTC'))
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          | Status | Count |
-          |--------|-------|
+          cat > /tmp/dashboard.md << EOF
+          # Factory Dashboard
+
+          Status aggregation for the dark factory autonomous engineering loop.
+
+          **Legend:** Queued → In Progress → Draft PR → PR Created → Human Review & Merge
+
+          ---
+
+          ## Status ($(date -u '+%Y-%m-%d %H:%M UTC'))
+
+          | Stage | Count |
+          |-------|-------|
           | Queued (claude:implement) | $QUEUED |
           | In Progress | $IN_PROGRESS |
           | Draft PR (CI pending) | $PR_DRAFT |
@@ -137,10 +147,10 @@ jobs:
           | Auto-fix (attempt 1/2/3) | $AUTOFIX_1 / $AUTOFIX_2 / $AUTOFIX_3 |
           | Blocked | $BLOCKED |
 
-          *Updated by factory-orchestrator (run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))*
+          *Updated by factory-orchestrator ([run ${{ github.run_id }}]($RUN_URL))*
           EOF
 
           sed -i 's/^          //' /tmp/dashboard.md
 
-          gh issue comment "$DASHBOARD" --repo "$REPO" --body-file /tmp/dashboard.md
-          echo "Dashboard updated."
+          gh issue edit "$DASHBOARD" --repo "$REPO" --body-file /tmp/dashboard.md
+          echo "Dashboard updated (issue body edited)."

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -56,4 +56,19 @@ jobs:
 
             Low-severity findings: create issues with type:chore and source:security-scan only.
 
-            Write summary to /tmp/summary.md and post to Factory Dashboard issue if it exists.
+            Write summary to /tmp/summary.md.
+
+            Post the summary as a sticky comment on the "[Factory Dashboard]" issue (find-or-create pattern):
+              MARKER="<!-- factory:security-scan -->"
+              DASHBOARD=$(gh issue list --repo ${{ github.repository }} --search "[Factory Dashboard]" --state open --json number --jq '.[0].number')
+              if [ -n "$DASHBOARD" ]; then
+                COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/$DASHBOARD/comments \
+                  --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+                echo "$MARKER" | cat - /tmp/summary.md > /tmp/summary-marked.md
+                if [ -n "$COMMENT_ID" ]; then
+                  gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
+                    -X PATCH -f body=@/tmp/summary-marked.md
+                else
+                  gh issue comment "$DASHBOARD" --repo ${{ github.repository }} --body-file /tmp/summary-marked.md
+                fi
+              fi

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -53,4 +53,19 @@ jobs:
                - Body should describe what's untested and suggest test cases
             c. If matching issue exists, add a comment with updated coverage data.
 
-            Write summary to /tmp/summary.md and post to Factory Dashboard issue if it exists.
+            Write summary to /tmp/summary.md.
+
+            Post the summary as a sticky comment on the "[Factory Dashboard]" issue (find-or-create pattern):
+              MARKER="<!-- factory:test-coverage -->"
+              DASHBOARD=$(gh issue list --repo ${{ github.repository }} --search "[Factory Dashboard]" --state open --json number --jq '.[0].number')
+              if [ -n "$DASHBOARD" ]; then
+                COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/$DASHBOARD/comments \
+                  --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+                echo "$MARKER" | cat - /tmp/summary.md > /tmp/summary-marked.md
+                if [ -n "$COMMENT_ID" ]; then
+                  gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
+                    -X PATCH -f body=@/tmp/summary-marked.md
+                else
+                  gh issue comment "$DASHBOARD" --repo ${{ github.repository }} --body-file /tmp/summary-marked.md
+                fi
+              fi

--- a/.github/workflows/workflow-upgrade.yml
+++ b/.github/workflows/workflow-upgrade.yml
@@ -46,4 +46,19 @@ jobs:
                - Apply labels with separate --add-label flags
             c. If matching issue exists, add a comment with updated version info.
 
-            Write summary to /tmp/summary.md and post to Factory Dashboard issue if it exists.
+            Write summary to /tmp/summary.md.
+
+            Post the summary as a sticky comment on the "[Factory Dashboard]" issue (find-or-create pattern):
+              MARKER="<!-- factory:workflow-upgrade -->"
+              DASHBOARD=$(gh issue list --repo ${{ github.repository }} --search "[Factory Dashboard]" --state open --json number --jq '.[0].number')
+              if [ -n "$DASHBOARD" ]; then
+                COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/$DASHBOARD/comments \
+                  --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+                echo "$MARKER" | cat - /tmp/summary.md > /tmp/summary-marked.md
+                if [ -n "$COMMENT_ID" ]; then
+                  gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
+                    -X PATCH -f body=@/tmp/summary-marked.md
+                else
+                  gh issue comment "$DASHBOARD" --repo ${{ github.repository }} --body-file /tmp/summary-marked.md
+                fi
+              fi


### PR DESCRIPTION
## Summary

- **Orchestrator** now edits the dashboard issue body directly (`gh issue edit --body-file`) instead of appending comments, showing current state at a glance
- **Assessment agents** use sticky comments with HTML markers (`<!-- factory:agent-name -->`) to find-and-update their reports in-place
- Dashboard issue body includes a persistent header with legend and status table

## Test plan

- [ ] Close old Factory Dashboard issue (#4)
- [ ] Create new dashboard issue with header template
- [ ] Trigger `factory-orchestrator` manually to verify it edits the issue body
- [ ] Run an assessment agent to verify sticky comment creation
- [ ] Run the same assessment agent again to verify it updates the existing comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)