### PR TITLE
fix: filter unsupported kwargs in extract_with_backend before dispatch

### DIFF
--- a/obsidian_import/registry.py
+++ b/obsidian_import/registry.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import importlib
+import inspect
+import logging
 import types
 from pathlib import Path
 
 from obsidian_import.config import BackendsConfig
 from obsidian_import.exceptions import BackendNotAvailableError, UnsupportedFormatError
+
+log = logging.getLogger(__name__)
 
 _EXTENSION_TO_CONFIG_KEY: dict[str, str] = {
     ".pdf": "pdf",
@@ -86,11 +90,27 @@ def extract_with_backend(path: Path, backends: BackendsConfig, timeout_seconds: 
     """Extract a file using the appropriate backend.
 
     Dispatches to the configured backend based on file extension.
+    Format-specific kwargs (e.g. max_rows_per_sheet for xlsx) are filtered to
+    only those the chosen backend's extract() function accepts. If a kwarg is
+    dropped, a warning is emitted so the capability gap is visible.
     """
     extension = path.suffix.lower()
     module = get_backend_module(extension, backends)
 
-    return module.extract(path, timeout_seconds=timeout_seconds, **kwargs)
+    sig = inspect.signature(module.extract)
+    accepted = set(sig.parameters.keys()) - {"path", "timeout_seconds"}
+    unsupported = {k for k in kwargs if k not in accepted}
+    if unsupported:
+        backend_name = module.__name__.split(".")[-1]
+        log.warning(
+            "backend '%s' does not support %s for %s; these options are ignored",
+            backend_name,
+            sorted(unsupported),
+            extension,
+        )
+    filtered_kwargs = {k: v for k, v in kwargs.items() if k not in unsupported}
+
+    return module.extract(path, timeout_seconds=timeout_seconds, **filtered_kwargs)
 
 
 def check_backend_available(backend_name: str, extension: str) -> tuple[bool, str]:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,10 +1,14 @@
 """Tests for extension dispatch and missing backend handling."""
 
+import types
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from obsidian_import.config import BackendsConfig
 from obsidian_import.exceptions import UnsupportedFormatError
-from obsidian_import.registry import check_backend_available, get_backend_module
+from obsidian_import.registry import check_backend_available, extract_with_backend, get_backend_module
 
 
 def _native_backends() -> BackendsConfig:
@@ -96,6 +100,66 @@ class TestGetBackendModule:
         )
         with pytest.raises(UnsupportedFormatError, match="Unknown backend"):
             get_backend_module(".pdf", backends)
+
+
+class TestExtractWithBackend:
+    def _markitdown_backends(self) -> BackendsConfig:
+        return BackendsConfig(
+            pdf="markitdown",
+            docx="markitdown",
+            pptx="markitdown",
+            xlsx="markitdown",
+            csv="markitdown",
+            json="markitdown",
+            yaml="markitdown",
+            image="markitdown",
+            default="markitdown",
+        )
+
+    def test_unsupported_kwarg_is_dropped_and_warned(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """max_rows_per_sheet must not reach markitdown.extract() which doesn't accept it."""
+        xlsx_file = tmp_path / "test.xlsx"
+        xlsx_file.write_bytes(b"fake")
+
+        fake_module = types.ModuleType("obsidian_import.backends.markitdown")
+        fake_module.extract = lambda path, timeout_seconds: "extracted"  # type: ignore[attr-defined]
+
+        import logging
+        with patch("obsidian_import.registry.get_backend_module", return_value=fake_module), \
+                caplog.at_level(logging.WARNING, logger="obsidian_import.registry"):
+            result = extract_with_backend(
+                    xlsx_file,
+                    backends=self._markitdown_backends(),
+                    timeout_seconds=30,
+                    max_rows_per_sheet=100,
+                )
+
+        assert result == "extracted"
+        assert any("max_rows_per_sheet" in r.message for r in caplog.records)
+
+    def test_supported_kwarg_is_forwarded(self, tmp_path: Path) -> None:
+        """max_rows_per_sheet must be forwarded when the backend accepts it."""
+        xlsx_file = tmp_path / "test.xlsx"
+        xlsx_file.write_bytes(b"fake")
+
+        received: dict = {}
+        fake_module = types.ModuleType("obsidian_import.backends.native_xlsx")
+
+        def fake_extract(path: Path, timeout_seconds: int, max_rows_per_sheet: int) -> str:
+            received["max_rows_per_sheet"] = max_rows_per_sheet
+            return "extracted"
+
+        fake_module.extract = fake_extract  # type: ignore[attr-defined]
+
+        with patch("obsidian_import.registry.get_backend_module", return_value=fake_module):
+            extract_with_backend(
+                xlsx_file,
+                backends=_native_backends(),
+                timeout_seconds=30,
+                max_rows_per_sheet=42,
+            )
+
+        assert received["max_rows_per_sheet"] == 42
 
 
 class TestCheckBackendAvailable:


### PR DESCRIPTION
## Summary

- `extract_with_backend()` in `registry.py` was blindly forwarding all `**kwargs` to `module.extract()`, causing `TypeError` when a format-specific kwarg was passed to a backend that doesn't accept it
- `extract_text()` and `extract_file()` in `__init__.py` inject `max_rows_per_sheet` for every `.xlsx` file regardless of configured backend — this is correct behaviour, but the dispatch layer wasn't handling the mismatch
- Fix: inspect the backend's `extract()` signature and filter kwargs to only accepted params; emit a `WARNING` log for any dropped capability-specific kwargs so the gap is visible

## Regression trigger

`m365-data-sync` configures `xlsx="markitdown"` in `ImportConfig`. Every `.xlsx` email attachment triggered:
```
attachment conversion failed error="extract() got an unexpected keyword argument 'max_rows_per_sheet'"
```

## Test plan

- [x] `test_unsupported_kwarg_is_dropped_and_warned` — verifies markitdown backend gets no `max_rows_per_sheet`, warning is emitted
- [x] `test_supported_kwarg_is_forwarded` — verifies native_xlsx backend receives `max_rows_per_sheet` unchanged
- [x] All 141 existing tests pass
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)