### PR TITLE
[code-quality] DRY: media config defaults duplicated between config.py

### DIFF
--- a/obsidian_import/config.py
+++ b/obsidian_import/config.py
@@ -103,11 +103,11 @@ def _build_config(raw: dict[str, Any], config_dir: Path | None) -> ImportConfig:
         output_raw = raw["output"]
         backends_raw = raw["backends"]
         extraction_raw = raw["extraction"]
+        media_raw = raw["media"]
     except KeyError as exc:
         raise ConfigError(f"Missing required config section: {exc}") from exc
 
     passthrough_raw = raw.get("passthrough", {})
-    media_raw = raw.get("media", {})
 
     directories: list[DirectoryConfig] = []
     for d in input_raw.get("directories", []):
@@ -166,9 +166,9 @@ def _build_config(raw: dict[str, Any], config_dir: Path | None) -> ImportConfig:
             patterns=passthrough_patterns,
         ),
         media=MediaConfig(
-            extract_images=bool(media_raw.get("extract_images", True)),
-            image_format=str(media_raw.get("image_format", "png")),
-            image_max_dimension=int(media_raw.get("image_max_dimension", 0)),
+            extract_images=bool(media_raw["extract_images"]),
+            image_format=str(media_raw["image_format"]),
+            image_max_dimension=int(media_raw["image_max_dimension"]),
         ),
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -127,6 +127,12 @@ class TestBuildConfig:
         with pytest.raises(ConfigError, match="Missing required config section"):
             _build_config({"input": {}, "output": {}, "backends": {}}, config_dir=None)
 
+    def test_missing_media_section_raises_config_error(self):
+        raw = _load_default_yaml()
+        del raw["media"]
+        with pytest.raises(ConfigError, match="Missing required config section"):
+            _build_config(raw, config_dir=None)
+
     def test_string_directory_raises_config_error(self):
         raw = _load_default_yaml()
         raw["input"]["directories"] = ["/tmp/docs"]


### PR DESCRIPTION
Closes #18

## Summary

Auto-implemented by Claude from issue #18.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)