### PR TITLE
fix: add upper-bound version pins for markitdown and docling optional…

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1944,7 +1944,7 @@ packages:
 - pypi: ./
   name: obsidian-import
   version: 1.0.0
-  sha256: 4cc4dd93a00d9a6cbd2e04fa90f80eb4a4d560c8bc96c1601d6f074e9b13a1a1
+  sha256: 75f97dd52722ab2ce3e06159dcb9ce93a190aaf695227831719a076426425881
   requires_dist:
   - pyyaml>=6.0,<7
   - click>=8.0,<9
@@ -1954,8 +1954,8 @@ packages:
   - python-pptx>=1.0,<2
   - openpyxl>=3.1,<4
   - pillow>=12.1,<13
-  - markitdown[all]>=0.1 ; extra == 'markitdown'
-  - docling>=2.0 ; extra == 'docling'
+  - markitdown[all]>=0.1,<0.2 ; extra == 'markitdown'
+  - docling>=2.0,<3 ; extra == 'docling'
   - pytest>=8.0,<9 ; extra == 'dev'
   - hypothesis>=6.0,<7 ; extra == 'dev'
   - pytest-cov>=5.0,<6 ; extra == 'dev'

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,7 +27,7 @@ pre-commit = ">=4.0,<5"
 mkdocs = ">=1.6,<2"
 mkdocs-material = ">=9.5,<10"
 mkdocstrings = {version = ">=0.29,<1", extras = ["python"]}
-docling = ">=2.0"
+docling = ">=2.0,<3"
 
 [tasks]
 lint = "ruff check obsidian_import/ tests/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-markitdown = ["markitdown[all]>=0.1"]
-docling = ["docling>=2.0"]
+markitdown = ["markitdown[all]>=0.1,<0.2"]
+docling = ["docling>=2.0,<3"]
 dev = ["pytest>=8.0,<9", "hypothesis>=6.0,<7", "pytest-cov>=5.0,<6"]
 
 [project.urls]


### PR DESCRIPTION
… deps

markitdown is pre-1.0, pinned to >=0.1,<0.2 per project standards. docling is stable, pinned to >=2.0,<3 per project standards. Updated both pyproject.toml and pixi.toml, and regenerated pixi.lock.

Closes #30