### PR TITLE
fix: address security and code quality issues (#14, #37, #59, #63, #64)

### DIFF
--- a/obsidian_import/backends/native_docx.py
+++ b/obsidian_import/backends/native_docx.py
@@ -88,6 +88,10 @@ def _extract_docx(path: Path, media_config: MediaConfig) -> ExtractionResult:
                             if embed_id and embed_id in rel_map:
                                 target = rel_map[embed_id]
                                 media_path = f"word/{target}" if not target.startswith("word/") else target
+                                if ".." in Path(media_path).parts:
+                                    continue
+                                if not media_path.startswith("word/media/"):
+                                    continue
                                 if media_path in zf.namelist():
                                     image_index += 1
                                     img_bytes = zf.read(media_path)

--- a/obsidian_import/backends/native_image.py
+++ b/obsidian_import/backends/native_image.py
@@ -27,7 +27,11 @@ def extract(path: Path, timeout_seconds: int, **kwargs: object) -> str:
 
     Returns markdown with a wikilink embed (![[filename]]).
     The image file itself must be copied to the vault separately.
+
+    timeout_seconds is accepted for backend interface compatibility
+    but not applied, as this function performs no blocking I/O.
     """
+    _ = timeout_seconds
     return f"![[{path.name}]]"
 
 

--- a/obsidian_import/discovery.py
+++ b/obsidian_import/discovery.py
@@ -32,8 +32,16 @@ def discover_files(config: ImportConfig) -> Iterator[DiscoveredFile]:
         if not directory.is_dir():
             continue
 
+        base_resolved = directory.resolve()
+
         for file_path in directory.rglob("*"):
+            if file_path.is_symlink():
+                continue
+
             if not file_path.is_file():
+                continue
+
+            if not file_path.resolve().is_relative_to(base_resolved):
                 continue
 
             extension = file_path.suffix.lower()

--- a/obsidian_import/media.py
+++ b/obsidian_import/media.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -88,8 +89,6 @@ def copy_media_files(
 
     Returns the list of destination paths.
     """
-    import shutil
-
     if not media_files:
         return []
 

--- a/obsidian_import/output.py
+++ b/obsidian_import/output.py
@@ -65,8 +65,8 @@ def _build_frontmatter(doc: ExtractedDocument, config: OutputConfig) -> str:
 
     lines = ["---"]
     for key, value in fields.items():
-        if "\n" in value or ":" in value or '"' in value:
-            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        if "\n" in value or "\r" in value or ":" in value or '"' in value:
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r")
             lines.append(f'{key}: "{escaped}"')
         else:
             lines.append(f"{key}: {value}")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -115,3 +115,20 @@ class TestDiscoverFiles:
 
         files = list(discover_files(config))
         assert len(files) == 2
+
+    def test_skips_symlinks(self, tmp_path):
+        """Symlinks are skipped to prevent traversal outside input directory."""
+        (tmp_path / "real.pdf").write_bytes(b"pdf")
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.pdf").write_bytes(b"secret")
+
+        (tmp_path / "link.pdf").symlink_to(outside / "secret.pdf")
+
+        config = _make_config((DirectoryConfig(path=str(tmp_path), extensions=(".pdf",), exclude=()),))
+
+        files = list(discover_files(config))
+        names = {f.path.name for f in files}
+        assert "real.pdf" in names
+        assert "link.pdf" not in names

--- a/tests/test_native_docx.py
+++ b/tests/test_native_docx.py
@@ -160,6 +160,86 @@ class TestNativeDocxExtract:
         assert "![[media/" not in result.markdown
         assert result.media_files[0].media_type == "image"
 
+    def test_path_traversal_in_relationship_target_skipped(self, tmp_path):
+        """DOCX with path traversal in relationship target skips the image."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+            xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:r><w:t>Text</w:t></w:r>
+      <w:r>
+        <w:drawing>
+          <wp:inline>
+            <a:graphic>
+              <a:graphicData>
+                <a:blip r:embed="rId1"/>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>"""
+
+        rels_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Target="../docProps/core.xml"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
+</Relationships>"""
+
+        docx_path = tmp_path / "traversal.docx"
+        with zipfile.ZipFile(str(docx_path), "w") as zf:
+            zf.writestr("word/document.xml", xml)
+            zf.writestr("word/_rels/document.xml.rels", rels_xml)
+            zf.writestr("docProps/core.xml", b"<secret>data</secret>")
+
+        result = extract(docx_path, timeout_seconds=30, media_config=_TEST_MEDIA_CONFIG)
+        assert result.media_files == ()
+
+    def test_non_media_relationship_target_skipped(self, tmp_path):
+        """DOCX with relationship target outside word/media/ is skipped."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+            xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:r><w:t>Text</w:t></w:r>
+      <w:r>
+        <w:drawing>
+          <wp:inline>
+            <a:graphic>
+              <a:graphicData>
+                <a:blip r:embed="rId1"/>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>"""
+
+        rels_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Target="embeddings/oleObject1.bin"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
+</Relationships>"""
+
+        docx_path = tmp_path / "nonmedia.docx"
+        with zipfile.ZipFile(str(docx_path), "w") as zf:
+            zf.writestr("word/document.xml", xml)
+            zf.writestr("word/_rels/document.xml.rels", rels_xml)
+            zf.writestr("word/embeddings/oleObject1.bin", b"binary data")
+
+        result = extract(docx_path, timeout_seconds=30, media_config=_TEST_MEDIA_CONFIG)
+        assert result.media_files == ()
+
     def test_no_images_when_disabled(self, tmp_path):
         """When extract_images=False, no images should be extracted."""
         docx = _make_docx(tmp_path, "simple.docx", _SIMPLE_DOC)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
@@ -88,6 +89,52 @@ class TestFormatOutput:
         doc = _make_doc("C:\\Users\\report: final", "# Hello")
         result = format_output(doc, _make_config(True))
         assert 'title: "C:\\\\Users\\\\report: final"' in result
+
+    def test_newlines_escaped_in_frontmatter(self):
+        """Literal newlines in values are escaped to prevent YAML injection."""
+        doc = ExtractedDocument(
+            source_path=Path("/tmp/file\ninjected: evil"),
+            markdown="# Hello",
+            title="safe",
+            file_type="pdf",
+            page_count=None,
+            associated_files=(),
+            media_files=(),
+        )
+        config = OutputConfig(
+            directory="./out",
+            frontmatter=True,
+            metadata_fields=("original_path",),
+        )
+        result = format_output(doc, config)
+        lines = result.split("\n")
+        for line in lines:
+            if line.startswith("original_path:"):
+                assert "\\n" in line
+                assert "\ninjected" not in line
+                break
+        else:
+            pytest.fail("original_path not found in frontmatter")
+
+    def test_carriage_return_escaped_in_frontmatter(self):
+        """Carriage returns are also escaped in quoted YAML values."""
+        doc = ExtractedDocument(
+            source_path=Path("/tmp/file\rinjected"),
+            markdown="# Hello",
+            title="safe",
+            file_type="pdf",
+            page_count=None,
+            associated_files=(),
+            media_files=(),
+        )
+        config = OutputConfig(
+            directory="./out",
+            frontmatter=True,
+            metadata_fields=("original_path",),
+        )
+        result = format_output(doc, config)
+        assert "\\r" in result
+        assert "\rinjected" not in result
 
 
 class TestOutputPathFor:


### PR DESCRIPTION
## Summary

- **#14 (security)**: Skip symlinks in `discover_files()` to prevent traversal outside configured input directories. Symlinks are now explicitly skipped, and resolved paths are validated against the base directory.
- **#37 (security)**: Escape literal `\n` and `\r` characters in YAML frontmatter values to prevent injection of malformed YAML scalars. Also added `\r` to the quoting trigger condition.
- **#59 (security)**: Restrict DOCX embedded image extraction to the `word/media/` path only. Reject relationship targets containing `..` path segments or pointing outside `word/media/`.
- **#64 (code-quality)**: Move `import shutil` from lazy function-body import to top-level in `media.py`, consistent with other stdlib imports.
- **#63 (code-quality)**: Document that `timeout_seconds` in `native_image.extract()` is accepted for interface compatibility but unused, and explicitly discard it with `_ = timeout_seconds`.

## Test plan

- [x] New test: `test_skips_symlinks` — verifies symlinks are excluded from discovery
- [x] New test: `test_newlines_escaped_in_frontmatter` — verifies `\n` is escaped to `\\n` in YAML
- [x] New test: `test_carriage_return_escaped_in_frontmatter` — verifies `\r` is escaped to `\\r`
- [x] New test: `test_path_traversal_in_relationship_target_skipped` — verifies `../` targets are rejected
- [x] New test: `test_non_media_relationship_target_skipped` — verifies non-media paths are rejected
- [x] All existing tests pass
- [x] ruff lint and format checks pass

Closes #14, closes #37, closes #59, closes #63, closes #64

https://claude.ai/code/session_01SKAkLqHS3KWndtWTd8SaXz