### PR TITLE
[test-coverage] native_pdf: 98% - blank page fallback and XObjects Key

### DIFF
--- a/tests/test_native_pdf_extract.py
+++ b/tests/test_native_pdf_extract.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from obsidian_import.backends.native_pdf import extract
+from obsidian_import.backends.native_pdf import _extract_page_content, extract
 from obsidian_import.config import MediaConfig
 from obsidian_import.extraction_result import MediaFile
 
@@ -218,6 +218,29 @@ class TestNativePdfExtract:
         assert "## Form Fields" in result.markdown
         assert "**FullName** (/Tx): Alice" in result.markdown
         assert "**Checkbox1** (/Btn): /Yes" in result.markdown
+
+    def test_blank_page_returns_empty_string(self):
+        """Page with no text, tables, or images returns ('', []) (line 116)."""
+        mock_page = MagicMock()
+        mock_page.extract_tables.return_value = []
+        mock_page.extract_text.return_value = ""
+
+        mock_reader_page = MagicMock()
+        mock_reader_page.get.return_value = None
+
+        mock_reader = MagicMock()
+        mock_reader.pages = [mock_reader_page]
+
+        result_text, result_media = _extract_page_content(
+            mock_page,
+            mock_reader,
+            page_number=1,
+            path=Path("/fake.pdf"),
+            media_config=_TEST_MEDIA_CONFIG,
+        )
+
+        assert result_text == ""
+        assert result_media == []
 
     def test_empty_table_guard(self, tmp_path):
         pdf_path = tmp_path / "empty_table.pdf"

--- a/tests/test_native_pdf_images.py
+++ b/tests/test_native_pdf_images.py
@@ -137,6 +137,39 @@ class TestExtractPageImages:
         result = _extract_page_images(mock_reader, 0, Path("/fake.pdf"), media_config)
         assert result == []
 
+    def test_xobject_key_error_logs_warning(self):
+        """KeyError raised while accessing XObject entries logs warning (line 166)."""
+        mock_xobject_dict = MagicMock()
+        mock_xobject_dict.__iter__.return_value = iter(["img0"])
+        mock_xobject_dict.__getitem__.side_effect = KeyError("missing xobject entry")
+
+        mock_xobjects = MagicMock()
+        mock_xobjects.get_object.return_value = mock_xobject_dict
+
+        mock_resources = MagicMock()
+        mock_resources.get.side_effect = lambda k: mock_xobjects if k == "/XObject" else None
+
+        mock_page = MagicMock()
+        mock_page.get.side_effect = lambda k: mock_resources if k == "/Resources" else None
+
+        mock_reader = MagicMock()
+        mock_reader.pages = [mock_page]
+
+        media_config = MediaConfig(
+            extract_images=True,
+            image_format="png",
+            image_max_dimension=0,
+            image_max_bytes=50_000_000,
+            image_allowed_formats=frozenset({"PNG", "JPEG", "GIF", "BMP", "TIFF", "WEBP"}),
+        )
+
+        with patch("obsidian_import.backends.native_pdf.log") as mock_log:
+            result = _extract_page_images(mock_reader, 0, Path("/fake.pdf"), media_config)
+
+        assert result == []
+        mock_log.warning.assert_called_once()
+        assert "XObjects" in mock_log.warning.call_args[0][0]
+
 
 class TestPdfImageExtension:
     def test_none_filter_returns_png(self):


### PR DESCRIPTION
Closes #107

## Summary

Auto-implemented by Claude from issue #107.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)