### PR TITLE
[code-quality] YAGNI: dead **kwargs on simple backends (csv, json, yam

### DIFF
--- a/obsidian_import/backends/native_csv.py
+++ b/obsidian_import/backends/native_csv.py
@@ -12,7 +12,7 @@ from obsidian_import.formatting import render_markdown_table
 from obsidian_import.timeout import run_with_timeout
 
 
-def extract(path: Path, timeout_seconds: int, **kwargs: object) -> str:
+def extract(path: Path, timeout_seconds: int) -> str:
     """Extract a CSV file as a GFM markdown table."""
     return run_with_timeout(lambda: _extract_csv(path), timeout_seconds, "CSV", path)
 

--- a/obsidian_import/backends/native_image.py
+++ b/obsidian_import/backends/native_image.py
@@ -22,7 +22,7 @@ _IMAGE_EXTENSIONS: frozenset[str] = frozenset(
 )
 
 
-def extract(path: Path, timeout_seconds: int, **kwargs: object) -> str:
+def extract(path: Path, timeout_seconds: int) -> str:
     """Generate an Obsidian-flavored markdown embed for an image file.
 
     Returns markdown with a wikilink embed (![[filename]]).
@@ -31,7 +31,6 @@ def extract(path: Path, timeout_seconds: int, **kwargs: object) -> str:
     timeout_seconds is accepted for backend interface compatibility
     but not applied, as this function performs no blocking I/O.
     """
-    _ = timeout_seconds
     return f"![[{path.name}]]"
 
 

--- a/obsidian_import/backends/native_json.py
+++ b/obsidian_import/backends/native_json.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from obsidian_import.timeout import run_with_timeout
 
 
-def extract(path: Path, timeout_seconds: int, **kwargs: object) -> str:
+def extract(path: Path, timeout_seconds: int) -> str:
     """Extract a JSON file as a fenced code block in markdown."""
     return run_with_timeout(lambda: _extract_json(path), timeout_seconds, "JSON", path)
 

--- a/obsidian_import/backends/native_yaml.py
+++ b/obsidian_import/backends/native_yaml.py
@@ -13,7 +13,7 @@ import yaml
 from obsidian_import.timeout import run_with_timeout
 
 
-def extract(path: Path, timeout_seconds: int, **kwargs: object) -> str:
+def extract(path: Path, timeout_seconds: int) -> str:
     """Extract a YAML file as a fenced code block in markdown."""
     return run_with_timeout(lambda: _extract_yaml(path), timeout_seconds, "YAML", path)
 


### PR DESCRIPTION
Closes #164

## Summary

Auto-implemented by Claude from issue #164.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)