### PR TITLE
chore: address security vulnerabilities in dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@
 
 ### Security
 
+* bump pip floor to >=26.1 for CVE-2026-6357 ([#183](https://github.com/neuralsignal/obsidian-import/issues/183))
+* bump pytest floor to >=9.0.3 for CVE-2025-71176 ([#184](https://github.com/neuralsignal/obsidian-import/issues/184))
+* pin cryptography >=46.0.7 for CVE-2026-39892 ([#181](https://github.com/neuralsignal/obsidian-import/issues/181))
+* drop direct twisted dep to remove CVE-2026-42304 exposure ([#185](https://github.com/neuralsignal/obsidian-import/issues/185))
+* track CVE-2026-3219 in pip (build-only dep, no fix available yet) ([#182](https://github.com/neuralsignal/obsidian-import/issues/182))
 * bump pypdf >=6.10.2 to address multiple High-severity DoS CVEs (CVE-2026-40260, GHSA-jj6c-8h6c-hppx, GHSA-4pxv-j86v-mhcw, GHSA-7gw9-cf7v-778f, GHSA-x284-j5p8-9c5p) ([#126](https://github.com/neuralsignal/obsidian-import/issues/126))
 
 ## [1.0.4](https://github.com/neuralsignal/obsidian-import/compare/v1.0.3...v1.0.4) (2026-04-13)

--- a/known-vulnerabilities.json
+++ b/known-vulnerabilities.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "CVE-2026-3219",
+    "package": "pip",
+    "reason": "No fix available as of 2026-05-18. pip is a build/dev-only dependency (not bundled in distributed package). See #182.",
+    "expires": "2026-08-18"
+  }
+]

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,7 +8,7 @@ version = "1.1.1" # x-release-please-version
 python = ">=3.12,<3.15"
 python-build = ">=1.4.0,<2"
 hatchling = ">=1.28.0,<2"
-pip = ">=26.0,<27"
+pip = ">=26.1,<27"  # CVE-2026-3219: no fix available as of 2026-05-18, build-only dep
 setuptools = ">=78.1.1,<79"
 
 [pypi-dependencies]
@@ -22,7 +22,7 @@ python-pptx = ">=1.0,<2"
 openpyxl = ">=3.1,<4"
 idna = ">=3.7,<4"
 Pillow = ">=12.2,<13"
-pytest = ">=8.0,<9"
+pytest = ">=9.0.3,<10"
 hypothesis = ">=6.0,<7"
 ruff = ">=0.11,<1"
 pytest-cov = ">=5.0,<6"
@@ -33,10 +33,10 @@ mkdocstrings = {version = ">=0.29,<1", extras = ["python"]}
 docling = ">=2.0,<3"
 pyasn1 = ">=0.6.3,<1"
 jinja2 = ">=3.1.6,<4"
-twisted = ">=24.7.0,<25"
 pyjwt = ">=2.12.0,<3"
 urllib3 = ">=2.7.0,<3"
 pyopenssl = ">=26.0.0,<27"
+cryptography = ">=46.0.7,<47"
 
 [tasks]
 lint = "ruff check obsidian_import/ tests/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 [project.optional-dependencies]
 markitdown = ["markitdown[all]>=0.1,<0.2"]
 docling = ["docling>=2.0,<3"]
-dev = ["pytest>=8.0,<9", "hypothesis>=6.0,<7", "pytest-cov>=5.0,<6"]
+dev = ["pytest>=9.0.3,<10", "hypothesis>=6.0,<7", "pytest-cov>=5.0,<6"]
 
 [project.urls]
 Documentation = "https://neuralsignal.github.io/obsidian-import/"


### PR DESCRIPTION
## Summary

This PR addresses multiple security vulnerabilities across the project's dependencies by updating version constraints and removing an unsafe transitive dependency. A new `known-vulnerabilities.json` file tracks CVEs in build-only dependencies that lack fixes.

## Changes

- **pip**: Bumped floor from `>=26.0` to `>=26.1` to address CVE-2026-6357
- **pytest**: Bumped floor from `>=8.0` to `>=9.0.3` to address CVE-2025-71176
- **cryptography**: Added explicit pin `>=46.0.7,<47` to address CVE-2026-39892
- **twisted**: Removed direct dependency to eliminate CVE-2026-42304 exposure (was an indirect transitive dependency)
- **known-vulnerabilities.json**: New file to track CVE-2026-3219 in pip (build-only dependency with no available fix as of 2026-05-18; expires 2026-08-18)
- **CHANGELOG.md**: Added security section documenting all CVE remediations with issue references

## Implementation Details

- All version bumps follow the existing pinning convention (`>=floor,<next-major`)
- The `twisted` removal required no code changes—it was only a transitive dependency
- The `known-vulnerabilities.json` file provides transparency on accepted CVE risk for build-only dependencies, with expiration dates to force periodic review
- Updated both `pixi.toml` and `pyproject.toml` to keep dependency specifications in sync

## Verification

- All changes are dependency-only; no source code logic modified
- CHANGELOG entries reference corresponding issue numbers for traceability
- Version constraints maintain compatibility with existing code

https://claude.ai/code/session_017NX37x5UPhteh498rHkg8S