### PR TITLE
[security-scan] thread-unsafe: Image.MAX_IMAGE_PIXELS global mutation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Security
 
+* serialize Image.MAX_IMAGE_PIXELS mutation with threading.Lock for thread safety ([#194](https://github.com/neuralsignal/obsidian-import/issues/194))
 * bump pip floor to >=26.1 for CVE-2026-6357 ([#183](https://github.com/neuralsignal/obsidian-import/issues/183))
 * bump pytest floor to >=9.0.3 for CVE-2025-71176 ([#184](https://github.com/neuralsignal/obsidian-import/issues/184))
 * pin cryptography >=46.0.7 for CVE-2026-39892 ([#181](https://github.com/neuralsignal/obsidian-import/issues/181))

--- a/obsidian_import/media.py
+++ b/obsidian_import/media.py
@@ -7,6 +7,7 @@ import io
 import logging
 import shutil
 import tempfile
+import threading
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -19,6 +20,8 @@ from obsidian_import.exceptions import ExtractionError
 from obsidian_import.extraction_result import MediaFile
 
 log = logging.getLogger(__name__)
+
+_pixel_limit_lock = threading.Lock()
 
 
 def generate_media_filename(context: str, index: int, extension: str) -> str:
@@ -158,8 +161,8 @@ def _encode_image(img: Image.Image, media_config: MediaConfig) -> bytes:
 def _process_image_bytes(image_bytes: bytes, media_config: MediaConfig) -> bytes:
     """Apply format conversion and resizing to image bytes.
 
-    Scopes Image.MAX_IMAGE_PIXELS mutation to this function's lifetime so it
-    cannot leak across threads or callers (see PR #163).
+    Serializes access to Image.MAX_IMAGE_PIXELS via _pixel_limit_lock to
+    prevent concurrent threads from racing on the global.
     """
     _validate_byte_size(image_bytes, media_config)
 
@@ -168,19 +171,20 @@ def _process_image_bytes(image_bytes: bytes, media_config: MediaConfig) -> bytes
     except ImportError as exc:
         raise ExtractionError("Pillow is required for image extraction. Install with: pip install Pillow") from exc
 
-    old_limit = Image.MAX_IMAGE_PIXELS
-    try:
-        if media_config.image_max_pixels > 0:
-            Image.MAX_IMAGE_PIXELS = media_config.image_max_pixels
-        else:
-            Image.MAX_IMAGE_PIXELS = None
+    with _pixel_limit_lock:
+        old_limit = Image.MAX_IMAGE_PIXELS
+        try:
+            if media_config.image_max_pixels > 0:
+                Image.MAX_IMAGE_PIXELS = media_config.image_max_pixels
+            else:
+                Image.MAX_IMAGE_PIXELS = None
 
-        img = _open_image_safely(image_bytes, media_config)
-        _validate_image_format(img, media_config)
-        img = _resize_if_needed(img, media_config)
-        return _encode_image(img, media_config)
-    finally:
-        Image.MAX_IMAGE_PIXELS = old_limit
+            img = _open_image_safely(image_bytes, media_config)
+            _validate_image_format(img, media_config)
+            img = _resize_if_needed(img, media_config)
+            return _encode_image(img, media_config)
+        finally:
+            Image.MAX_IMAGE_PIXELS = old_limit
 
 
 def copy_media_files(

--- a/tests/test_media_validation.py
+++ b/tests/test_media_validation.py
@@ -1,6 +1,7 @@
 """Tests for image bytes validation in media processing."""
 
 import io
+import threading
 
 import pytest
 from conftest import make_png_bytes
@@ -13,6 +14,7 @@ from obsidian_import.exceptions import ExtractionError
 from obsidian_import.media import (
     _encode_image,
     _open_image_safely,
+    _pixel_limit_lock,
     _process_image_bytes,
     _resize_if_needed,
     _validate_byte_size,
@@ -155,6 +157,37 @@ class TestMaxImagePixelsRestored:
         with pytest.raises(ExtractionError):
             _process_image_bytes(img_bytes, config)
         assert sentinel == _Image.MAX_IMAGE_PIXELS
+
+    def test_pixel_limit_lock_serializes_concurrent_access(self) -> None:
+        """Verify _pixel_limit_lock prevents concurrent MAX_IMAGE_PIXELS mutation."""
+        from PIL import Image as _Image
+
+        sentinel = _Image.MAX_IMAGE_PIXELS
+        img_bytes = make_png_bytes(10, 10, "RGB")
+        config = _make_config(
+            image_max_bytes=50_000_000,
+            image_allowed_formats=frozenset({"PNG"}),
+            image_max_pixels=1_000,
+        )
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                _process_image_bytes(img_bytes, config)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert sentinel == _Image.MAX_IMAGE_PIXELS
+
+    def test_pixel_limit_lock_is_a_lock(self) -> None:
+        assert isinstance(_pixel_limit_lock, type(threading.Lock()))
 
 
 class TestImagePixelCountValidation:


### PR DESCRIPTION
Closes #194

## Summary

Auto-implemented by Claude from issue #194.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)