### PR TITLE
[security-scan] zip-bomb-via-falsified-metadata: _check_zip_entry_size

### DIFF
--- a/obsidian_import/backends/native_docx.py
+++ b/obsidian_import/backends/native_docx.py
@@ -50,14 +50,19 @@ def extract(
     return run_with_timeout(_extract_docx, (path, media_config, max_file_size_mb), ctx)
 
 
-def _check_zip_entry_size(zf: zipfile.ZipFile, entry_name: str, max_bytes: int, path: Path) -> None:
-    """Raise ExtractionError if a ZIP entry's uncompressed size exceeds max_bytes."""
-    info = zf.getinfo(entry_name)
-    if info.file_size > max_bytes:
-        raise ExtractionError(
-            f"ZIP entry '{entry_name}' in {path} has uncompressed size "
-            f"{info.file_size} bytes, exceeding limit of {max_bytes} bytes"
-        )
+def _read_zip_entry_bounded(zf: zipfile.ZipFile, entry_name: str, max_bytes: int, path: Path) -> bytes:
+    """Stream-decompress a ZIP entry, raising if actual size exceeds max_bytes."""
+    chunks: list[bytes] = []
+    total = 0
+    with zf.open(entry_name) as f:
+        while chunk := f.read(65_536):
+            total += len(chunk)
+            if total > max_bytes:
+                raise ExtractionError(
+                    f"ZIP entry '{entry_name}' in {path} exceeds decompressed limit of {max_bytes} bytes"
+                )
+            chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _extract_docx(path: Path, media_config: MediaConfig, max_file_size_mb: int) -> ExtractionResult:
@@ -73,8 +78,7 @@ def _extract_docx(path: Path, media_config: MediaConfig, max_file_size_mb: int) 
         if "word/document.xml" not in zf.namelist():
             raise ExtractionError(f"No word/document.xml found in: {path}")
 
-        _check_zip_entry_size(zf, "word/document.xml", max_bytes, path)
-        doc_xml = zf.read("word/document.xml")
+        doc_xml = _read_zip_entry_bounded(zf, "word/document.xml", max_bytes, path)
         root = fromstring(doc_xml)
 
         rel_map = _build_rel_map(zf, fromstring, max_bytes, path)
@@ -155,8 +159,7 @@ def _build_rel_map(zf: zipfile.ZipFile, fromstring: object, max_bytes: int, path
     if "word/_rels/document.xml.rels" not in zf.namelist():
         return rel_map
 
-    _check_zip_entry_size(zf, "word/_rels/document.xml.rels", max_bytes, path)
-    rels_xml = zf.read("word/_rels/document.xml.rels")
+    rels_xml = _read_zip_entry_bounded(zf, "word/_rels/document.xml.rels", max_bytes, path)
     rels_root = fromstring(rels_xml)  # type: ignore[operator]
     for rel in rels_root:
         rid = rel.get("Id", "")
@@ -192,9 +195,8 @@ def _extract_docx_images(
                 continue
             if media_path not in zip_ctx.zf.namelist():
                 continue
-            _check_zip_entry_size(zip_ctx.zf, media_path, zip_ctx.max_bytes, zip_ctx.path)
             image_index += 1
-            img_bytes = zip_ctx.zf.read(media_path)
+            img_bytes = _read_zip_entry_bounded(zip_ctx.zf, media_path, zip_ctx.max_bytes, zip_ctx.path)
             orig_ext = Path(media_path).suffix
             filename = generate_media_filename("doc", image_index, orig_ext)
             mf = attempt_save_image(

--- a/tests/test_native_docx.py
+++ b/tests/test_native_docx.py
@@ -224,7 +224,7 @@ class TestDecompressionBombGuard:
         with zipfile.ZipFile(str(docx_path), "w", compression=zipfile.ZIP_DEFLATED) as zf:
             zf.writestr("word/document.xml", large_xml)
 
-        with pytest.raises(ExtractionError, match="uncompressed size"):
+        with pytest.raises(ExtractionError, match="decompressed limit"):
             extract(
                 docx_path, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG, max_file_size_mb=1
             )
@@ -242,7 +242,7 @@ class TestDecompressionBombGuard:
             zf.writestr("word/document.xml", small_doc)
             zf.writestr("word/_rels/document.xml.rels", large_rels)
 
-        with pytest.raises(ExtractionError, match="uncompressed size"):
+        with pytest.raises(ExtractionError, match="decompressed limit"):
             extract(
                 docx_path, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG, max_file_size_mb=1
             )
@@ -285,7 +285,7 @@ class TestDecompressionBombGuard:
             zf.writestr("word/_rels/document.xml.rels", rels_xml)
             zf.writestr("word/media/image1.png", large_image)
 
-        with pytest.raises(ExtractionError, match="uncompressed size"):
+        with pytest.raises(ExtractionError, match="decompressed limit"):
             extract(
                 docx_path, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG, max_file_size_mb=1
             )

--- a/tests/test_native_docx_images.py
+++ b/tests/test_native_docx_images.py
@@ -237,7 +237,7 @@ class TestDecompressionBombGuard:
         )
         docx_path = _make_docx(tmp_path, "bomb.docx", {"word/document.xml": large_xml})
 
-        with pytest.raises(ExtractionError, match="uncompressed size"):
+        with pytest.raises(ExtractionError, match="decompressed limit"):
             _extract(docx_path, _TEST_MEDIA_CONFIG, max_file_size_mb=1)
 
     def test_oversized_rels_xml_raises(self, tmp_path):
@@ -253,7 +253,7 @@ class TestDecompressionBombGuard:
             {"word/document.xml": _SIMPLE_DOC, "word/_rels/document.xml.rels": large_rels},
         )
 
-        with pytest.raises(ExtractionError, match="uncompressed size"):
+        with pytest.raises(ExtractionError, match="decompressed limit"):
             _extract(docx_path, _TEST_MEDIA_CONFIG, max_file_size_mb=1)
 
     def test_oversized_media_entry_raises(self, tmp_path):
@@ -268,7 +268,7 @@ class TestDecompressionBombGuard:
             },
         )
 
-        with pytest.raises(ExtractionError, match="uncompressed size"):
+        with pytest.raises(ExtractionError, match="decompressed limit"):
             _extract(docx_path, _TEST_MEDIA_CONFIG, max_file_size_mb=1)
 
     def test_within_limit_succeeds(self, tmp_path):


### PR DESCRIPTION
Closes #254

## Summary

Auto-implemented by Claude from issue #254.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)