### PR TITLE
Consolidate open PRs: IPC hardening, complexity refactors, and dependency pins

### DIFF
--- a/obsidian_import/backends/native_pdf.py
+++ b/obsidian_import/backends/native_pdf.py
@@ -37,33 +37,14 @@ def _extract_pdf(path: Path, media_config: MediaConfig) -> ExtractionResult:
     import pdfplumber
     from pypdf import PdfReader
 
-    sections: list[str] = []
+    reader = PdfReader(str(path))
+    title, metadata_lines = _extract_pdf_metadata(reader, path)
+    sections: list[str] = [f"# {title}", *metadata_lines]
     media_files: list[MediaFile] = []
 
-    reader = PdfReader(str(path))
-    meta = reader.metadata
-    if meta:
-        title = meta.title or path.stem
-        if meta.author:
-            sections.append(f"**Author:** {meta.author}")
-        if meta.creation_date:
-            sections.append(f"**Created:** {meta.creation_date}")
-    else:
-        title = path.stem
-
-    sections.insert(0, f"# {title}")
-
-    fields = reader.get_fields()
-    if fields:
-        field_lines = ["", "## Form Fields", ""]
-        for name, field in fields.items():
-            field_type = field.get("/FT", "unknown")
-            value = field.get("/V", "")
-            safe_name = sanitize_markdown_inline(str(name))
-            safe_type = sanitize_markdown_inline(str(field_type))
-            safe_value = sanitize_markdown_inline(str(value))
-            field_lines.append(f"- **{safe_name}** ({safe_type}): {safe_value}")
-        sections.append("\n".join(field_lines))
+    form_section = _extract_form_fields(reader)
+    if form_section is not None:
+        sections.append(form_section)
 
     with pdfplumber.open(str(path)) as pdf:
         for i, page in enumerate(pdf.pages, 1):
@@ -82,6 +63,38 @@ def _extract_pdf(path: Path, media_config: MediaConfig) -> ExtractionResult:
         markdown="\n\n".join(sections),
         media_files=tuple(media_files),
     )
+
+
+def _extract_pdf_metadata(reader: PdfReader, path: Path) -> tuple[str, list[str]]:
+    """Extract title and metadata lines from a PDF reader."""
+    meta = reader.metadata
+    if not meta:
+        return path.stem, []
+
+    title = meta.title or path.stem
+    lines: list[str] = []
+    if meta.author:
+        lines.append(f"**Author:** {meta.author}")
+    if meta.creation_date:
+        lines.append(f"**Created:** {meta.creation_date}")
+    return title, lines
+
+
+def _extract_form_fields(reader: PdfReader) -> str | None:
+    """Render PDF form fields as a markdown section, or None if no fields exist."""
+    fields = reader.get_fields()
+    if not fields:
+        return None
+
+    field_lines = ["", "## Form Fields", ""]
+    for name, field in fields.items():
+        field_type = field.get("/FT", "unknown")
+        value = field.get("/V", "")
+        safe_name = sanitize_markdown_inline(str(name))
+        safe_type = sanitize_markdown_inline(str(field_type))
+        safe_value = sanitize_markdown_inline(str(value))
+        field_lines.append(f"- **{safe_name}** ({safe_type}): {safe_value}")
+    return "\n".join(field_lines)
 
 
 def _extract_page_content(

--- a/obsidian_import/backends/native_pptx.py
+++ b/obsidian_import/backends/native_pptx.py
@@ -51,43 +51,54 @@ def _extract_pptx(path: Path, media_config: MediaConfig) -> ExtractionResult:
         sections.append(f'*Slide dimensions: {w_in:.1f}" x {h_in:.1f}"*')
 
     for i, slide in enumerate(prs.slides, 1):
-        slide_sections: list[str] = []
-
-        title = ""
-        if slide.shapes.title:
-            title = slide.shapes.title.text.strip()
-
-        if title:
-            slide_sections.append(f"## Slide {i}: {title}")
-        else:
-            slide_sections.append(f"## Slide {i}")
-
-        body_texts, slide_media = _extract_slide_content(
-            slide,
-            i,
-            path,
-            media_config,
-        )
+        slide_section, slide_media = _assemble_slide_section(slide, i, path, media_config)
+        sections.append(slide_section)
         media_files.extend(slide_media)
-
-        if body_texts:
-            slide_sections.append("\n".join(body_texts))
-
-        if slide.has_notes_slide:
-            notes_frame = slide.notes_slide.notes_text_frame
-            notes_text = notes_frame.text.strip() if notes_frame else ""
-            if notes_text:
-                slide_sections.append(f"\n> **Speaker Notes:** {notes_text}")
-
-        if len(slide_sections) > 1:
-            sections.append("\n\n".join(slide_sections))
-        else:
-            sections.append(slide_sections[0])
 
     return ExtractionResult(
         markdown="\n\n".join(sections),
         media_files=tuple(media_files),
     )
+
+
+def _assemble_slide_section(
+    slide: Slide,
+    slide_number: int,
+    path: Path,
+    media_config: MediaConfig,
+) -> tuple[str, list[MediaFile]]:
+    """Assemble the markdown section for a single slide."""
+    title = ""
+    if slide.shapes.title:
+        title = slide.shapes.title.text.strip()
+
+    if title:
+        slide_sections: list[str] = [f"## Slide {slide_number}: {title}"]
+    else:
+        slide_sections = [f"## Slide {slide_number}"]
+
+    body_texts, slide_media = _extract_slide_content(slide, slide_number, path, media_config)
+    if body_texts:
+        slide_sections.append("\n".join(body_texts))
+
+    notes = _extract_slide_notes(slide)
+    if notes is not None:
+        slide_sections.append(notes)
+
+    if len(slide_sections) > 1:
+        return "\n\n".join(slide_sections), slide_media
+    return slide_sections[0], slide_media
+
+
+def _extract_slide_notes(slide: Slide) -> str | None:
+    """Extract speaker notes from a slide, or None if empty/absent."""
+    if not slide.has_notes_slide:
+        return None
+    notes_frame = slide.notes_slide.notes_text_frame
+    notes_text = notes_frame.text.strip() if notes_frame else ""
+    if not notes_text:
+        return None
+    return f"\n> **Speaker Notes:** {notes_text}"
 
 
 def _extract_slide_content(

--- a/obsidian_import/config.py
+++ b/obsidian_import/config.py
@@ -107,22 +107,8 @@ def _load_default_yaml() -> dict[str, Any]:
     return yaml.safe_load(ref.read_text(encoding="utf-8"))
 
 
-def _build_config(raw: dict[str, Any], config_dir: Path | None) -> ImportConfig:
-    """Build ImportConfig from a raw dict. Resolve relative paths if config_dir given."""
-    if config_dir is not None and not config_dir.is_absolute():
-        config_dir = config_dir.resolve()
-
-    try:
-        input_raw = raw["input"]
-        output_raw = raw["output"]
-        backends_raw = raw["backends"]
-        extraction_raw = raw["extraction"]
-        media_raw = raw["media"]
-    except KeyError as exc:
-        raise ConfigError(f"Missing required config section: {exc}") from exc
-
-    passthrough_raw = raw.get("passthrough", {})
-
+def _build_input_config(input_raw: dict[str, Any]) -> InputConfig:
+    """Build InputConfig from the raw 'input' section."""
     directories: list[DirectoryConfig] = []
     for d in input_raw.get("directories", []):
         if isinstance(d, str):
@@ -143,52 +129,92 @@ def _build_config(raw: dict[str, Any], config_dir: Path | None) -> ImportConfig:
                 f"Directory config missing required key {exc}. "
                 "Each directory must have 'path', 'extensions', and 'exclude'."
             ) from exc
+    return InputConfig(directories=tuple(directories))
 
-    passthrough_patterns = tuple(passthrough_raw.get("patterns", ()))
-    for pattern in passthrough_patterns:
+
+def _build_output_config(output_raw: dict[str, Any]) -> OutputConfig:
+    """Build OutputConfig from the raw 'output' section."""
+    return OutputConfig(
+        directory=output_raw["directory"],
+        frontmatter=output_raw["frontmatter"],
+        metadata_fields=tuple(output_raw["metadata_fields"]),
+    )
+
+
+def _build_backends_config(backends_raw: dict[str, Any]) -> BackendsConfig:
+    """Build BackendsConfig from the raw 'backends' section."""
+    return BackendsConfig(
+        pdf=backends_raw["pdf"],
+        docx=backends_raw["docx"],
+        pptx=backends_raw["pptx"],
+        xlsx=backends_raw["xlsx"],
+        csv=backends_raw.get("csv", backends_raw["default"]),
+        json=backends_raw.get("json", backends_raw["default"]),
+        yaml=backends_raw.get("yaml", backends_raw["default"]),
+        image=backends_raw.get("image", backends_raw["default"]),
+        html=backends_raw.get("html", backends_raw["default"]),
+        default=backends_raw["default"],
+    )
+
+
+def _build_extraction_config(extraction_raw: dict[str, Any]) -> ExtractionConfig:
+    """Build ExtractionConfig from the raw 'extraction' section."""
+    return ExtractionConfig(
+        timeout_seconds=int(extraction_raw["timeout_seconds"]),
+        max_file_size_mb=int(extraction_raw["max_file_size_mb"]),
+        xlsx_max_rows_per_sheet=int(extraction_raw["xlsx_max_rows_per_sheet"]),
+        isolation=validated_isolation(extraction_raw["isolation"]),
+    )
+
+
+def _build_passthrough_config(passthrough_raw: dict[str, Any]) -> PassthroughConfig:
+    """Build PassthroughConfig from the raw 'passthrough' section."""
+    patterns = tuple(passthrough_raw.get("patterns", ()))
+    for pattern in patterns:
         try:
             re.compile(pattern)
         except re.error as exc:
             raise ConfigError(f"Invalid regex in passthrough.patterns: '{pattern}': {exc}") from exc
+    return PassthroughConfig(
+        extensions=tuple(passthrough_raw.get("extensions", ())),
+        paths=tuple(passthrough_raw.get("paths", ())),
+        patterns=patterns,
+    )
+
+
+def _build_media_config(media_raw: dict[str, Any]) -> MediaConfig:
+    """Build MediaConfig from the raw 'media' section."""
+    return MediaConfig(
+        extract_images=bool(media_raw["extract_images"]),
+        image_format=str(media_raw["image_format"]),
+        image_max_dimension=int(media_raw["image_max_dimension"]),
+        image_max_bytes=int(media_raw["image_max_bytes"]),
+        image_max_pixels=int(media_raw["image_max_pixels"]),
+        image_allowed_formats=frozenset(media_raw["image_allowed_formats"]),
+    )
+
+
+def _build_config(raw: dict[str, Any], config_dir: Path | None) -> ImportConfig:
+    """Build ImportConfig from a raw dict. Resolve relative paths if config_dir given."""
+    if config_dir is not None and not config_dir.is_absolute():
+        config_dir = config_dir.resolve()
+
+    try:
+        input_raw = raw["input"]
+        output_raw = raw["output"]
+        backends_raw = raw["backends"]
+        extraction_raw = raw["extraction"]
+        media_raw = raw["media"]
+    except KeyError as exc:
+        raise ConfigError(f"Missing required config section: {exc}") from exc
 
     return ImportConfig(
-        input=InputConfig(directories=tuple(directories)),
-        output=OutputConfig(
-            directory=output_raw["directory"],
-            frontmatter=output_raw["frontmatter"],
-            metadata_fields=tuple(output_raw["metadata_fields"]),
-        ),
-        backends=BackendsConfig(
-            pdf=backends_raw["pdf"],
-            docx=backends_raw["docx"],
-            pptx=backends_raw["pptx"],
-            xlsx=backends_raw["xlsx"],
-            csv=backends_raw.get("csv", backends_raw["default"]),
-            json=backends_raw.get("json", backends_raw["default"]),
-            yaml=backends_raw.get("yaml", backends_raw["default"]),
-            image=backends_raw.get("image", backends_raw["default"]),
-            html=backends_raw.get("html", backends_raw["default"]),
-            default=backends_raw["default"],
-        ),
-        extraction=ExtractionConfig(
-            timeout_seconds=int(extraction_raw["timeout_seconds"]),
-            max_file_size_mb=int(extraction_raw["max_file_size_mb"]),
-            xlsx_max_rows_per_sheet=int(extraction_raw["xlsx_max_rows_per_sheet"]),
-            isolation=validated_isolation(extraction_raw["isolation"]),
-        ),
-        passthrough=PassthroughConfig(
-            extensions=tuple(passthrough_raw.get("extensions", ())),
-            paths=tuple(passthrough_raw.get("paths", ())),
-            patterns=passthrough_patterns,
-        ),
-        media=MediaConfig(
-            extract_images=bool(media_raw["extract_images"]),
-            image_format=str(media_raw["image_format"]),
-            image_max_dimension=int(media_raw["image_max_dimension"]),
-            image_max_bytes=int(media_raw["image_max_bytes"]),
-            image_max_pixels=int(media_raw["image_max_pixels"]),
-            image_allowed_formats=frozenset(media_raw["image_allowed_formats"]),
-        ),
+        input=_build_input_config(input_raw),
+        output=_build_output_config(output_raw),
+        backends=_build_backends_config(backends_raw),
+        extraction=_build_extraction_config(extraction_raw),
+        passthrough=_build_passthrough_config(raw.get("passthrough", {})),
+        media=_build_media_config(media_raw),
     )
 
 

--- a/obsidian_import/extraction_result.py
+++ b/obsidian_import/extraction_result.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -14,6 +15,23 @@ class MediaFile:
     filename: str
     media_type: str
 
+    def to_dict(self) -> dict[str, str]:
+        """Serialize to a JSON-safe dict for IPC."""
+        return {
+            "source_path": str(self.source_path),
+            "filename": self.filename,
+            "media_type": self.media_type,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MediaFile:
+        """Reconstruct from a dict produced by to_dict."""
+        return cls(
+            source_path=Path(data["source_path"]),
+            filename=data["filename"],
+            media_type=data["media_type"],
+        )
+
 
 @dataclass(frozen=True)
 class ExtractionResult:
@@ -21,3 +39,18 @@ class ExtractionResult:
 
     markdown: str
     media_files: tuple[MediaFile, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe dict for IPC."""
+        return {
+            "markdown": self.markdown,
+            "media_files": [m.to_dict() for m in self.media_files],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExtractionResult:
+        """Reconstruct from a dict produced by to_dict."""
+        return cls(
+            markdown=data["markdown"],
+            media_files=tuple(MediaFile.from_dict(m) for m in data["media_files"]),
+        )

--- a/obsidian_import/ipc_codec.py
+++ b/obsidian_import/ipc_codec.py
@@ -1,0 +1,58 @@
+"""JSON wire codec for the parent/child extraction IPC.
+
+The child process sends ``[status, payload]`` as JSON bytes rather than a
+pickle, so a compromised or buggy child cannot achieve code execution in the
+parent through a crafted payload. Only the two result shapes extraction
+backends actually return travel the wire: ``str`` and ``ExtractionResult``.
+"""
+
+from __future__ import annotations
+
+import json
+from multiprocessing.connection import Connection
+
+from obsidian_import.exceptions import ExtractionError
+from obsidian_import.extraction_result import ExtractionResult
+
+WIRE_TYPE_STR = "str"
+WIRE_TYPE_EXTRACTION_RESULT = "ExtractionResult"
+
+_ENVELOPE_LENGTH = 2
+
+
+def serialize_payload(result: object) -> list[object]:
+    """Convert an extraction result to a JSON-safe [type_tag, value] pair."""
+    if isinstance(result, str):
+        return [WIRE_TYPE_STR, result]
+    if isinstance(result, ExtractionResult):
+        return [WIRE_TYPE_EXTRACTION_RESULT, result.to_dict()]
+    raise ExtractionError(
+        f"Process IPC cannot serialize {type(result).__name__}; only str and ExtractionResult are supported"
+    )
+
+
+def deserialize_payload(data: object) -> object:
+    """Reconstruct an extraction result from its JSON wire [type_tag, value] pair."""
+    if not is_envelope(data):
+        raise ExtractionError(f"Malformed IPC payload: expected [type, value], got {type(data).__name__}")
+    wire_type, value = data
+    if wire_type == WIRE_TYPE_STR:
+        if not isinstance(value, str):
+            raise ExtractionError(f"IPC type tag 'str' but value is {type(value).__name__}")
+        return value
+    if wire_type == WIRE_TYPE_EXTRACTION_RESULT:
+        if not isinstance(value, dict):
+            raise ExtractionError(f"IPC type tag 'ExtractionResult' but value is {type(value).__name__}")
+        return ExtractionResult.from_dict(value)
+    raise ExtractionError(f"Unknown IPC type tag: {wire_type!r}")
+
+
+def send_message(conn: Connection, status: str, payload: object) -> None:
+    """Send a [status, payload] message as JSON bytes over the connection."""
+    wire_payload = serialize_payload(payload) if status == "ok" else str(payload)
+    conn.send_bytes(json.dumps([status, wire_payload]).encode("utf-8"))
+
+
+def is_envelope(data: object) -> bool:
+    """True if a decoded message has the [status, payload] shape."""
+    return isinstance(data, list) and len(data) == _ENVELOPE_LENGTH

--- a/obsidian_import/timeout.py
+++ b/obsidian_import/timeout.py
@@ -28,7 +28,7 @@ from multiprocessing.connection import Connection
 from pathlib import Path
 
 from obsidian_import.exceptions import ConfigError, ExtractionError, ExtractionTimeoutError
-from obsidian_import.extraction_result import ExtractionResult
+from obsidian_import.ipc_codec import deserialize_payload, is_envelope, send_message
 
 VALID_ISOLATION_MODES: tuple[str, ...] = ("thread", "process")
 
@@ -135,52 +135,12 @@ def _run_in_thread[T](
     return result[0]
 
 
-_WIRE_TYPE_STR = "str"
-_WIRE_TYPE_EXTRACTION_RESULT = "ExtractionResult"
-
-
-def _serialize_payload(result: object) -> list[object]:
-    """Convert an extraction result to a JSON-safe [type_tag, value] pair."""
-    if isinstance(result, str):
-        return [_WIRE_TYPE_STR, result]
-    if isinstance(result, ExtractionResult):
-        return [_WIRE_TYPE_EXTRACTION_RESULT, result.to_dict()]
-    raise ExtractionError(
-        f"Process IPC cannot serialize {type(result).__name__}; only str and ExtractionResult are supported"
-    )
-
-
-def _deserialize_payload(data: object) -> object:
-    """Reconstruct an extraction result from its JSON wire [type_tag, value] pair."""
-    if not isinstance(data, list) or len(data) != 2:  # noqa: PLR2004
-        raise ExtractionError(f"Malformed IPC payload: expected [type, value], got {type(data).__name__}")
-    wire_type, value = data
-    if wire_type == _WIRE_TYPE_STR:
-        if not isinstance(value, str):
-            raise ExtractionError(f"IPC type tag 'str' but value is {type(value).__name__}")
-        return value
-    if wire_type == _WIRE_TYPE_EXTRACTION_RESULT:
-        if not isinstance(value, dict):
-            raise ExtractionError(f"IPC type tag 'ExtractionResult' but value is {type(value).__name__}")
-        return ExtractionResult.from_dict(value)
-    raise ExtractionError(f"Unknown IPC type tag: {wire_type!r}")
-
-
-def _ipc_send(conn: Connection, status: str, payload: object) -> None:
-    """Send a [status, payload] message as JSON bytes over the connection."""
-    if status == "ok":
-        wire_payload = _serialize_payload(payload)
-    else:
-        wire_payload = str(payload)
-    conn.send_bytes(json.dumps([status, wire_payload]).encode("utf-8"))
-
-
 def _process_worker(conn: Connection, fn: Callable[..., object], args: tuple[object, ...]) -> None:
     """Child-process entry point: run fn and send [status, payload] back via JSON."""
     try:
-        _ipc_send(conn, "ok", fn(*args))
+        send_message(conn, "ok", fn(*args))
     except BaseException as exc:  # noqa: BLE001 — process boundary: re-raised in parent
-        _ipc_send(conn, "err", f"{type(exc).__name__}: {exc}")
+        send_message(conn, "err", f"{type(exc).__name__}: {exc}")
     finally:
         conn.close()
 
@@ -196,13 +156,12 @@ def _recv_result(parent_conn: Connection, label: str, path: Path) -> tuple[str, 
     distinguishes timeout kills from spontaneous child death.
     """
     try:
-        raw = parent_conn.recv_bytes()
-        data = json.loads(raw)
-        if not isinstance(data, list) or len(data) != 2:  # noqa: PLR2004
+        data = json.loads(parent_conn.recv_bytes())
+        if not is_envelope(data):
             raise ExtractionError(f"{label} extraction IPC for {path}: malformed message structure")
         status, wire_payload = data
         if status == "ok":
-            return (status, _deserialize_payload(wire_payload))
+            return (status, deserialize_payload(wire_payload))
         return (status, wire_payload)
     except EOFError:
         raise

--- a/obsidian_import/timeout.py
+++ b/obsidian_import/timeout.py
@@ -18,8 +18,8 @@ Supports two isolation modes (config: extraction.isolation):
 
 from __future__ import annotations
 
+import json
 import multiprocessing
-import pickle
 import threading
 import time
 from collections.abc import Callable
@@ -28,6 +28,7 @@ from multiprocessing.connection import Connection
 from pathlib import Path
 
 from obsidian_import.exceptions import ConfigError, ExtractionError, ExtractionTimeoutError
+from obsidian_import.extraction_result import ExtractionResult
 
 VALID_ISOLATION_MODES: tuple[str, ...] = ("thread", "process")
 
@@ -134,47 +135,81 @@ def _run_in_thread[T](
     return result[0]
 
 
+_WIRE_TYPE_STR = "str"
+_WIRE_TYPE_EXTRACTION_RESULT = "ExtractionResult"
+
+
+def _serialize_payload(result: object) -> list[object]:
+    """Convert an extraction result to a JSON-safe [type_tag, value] pair."""
+    if isinstance(result, str):
+        return [_WIRE_TYPE_STR, result]
+    if isinstance(result, ExtractionResult):
+        return [_WIRE_TYPE_EXTRACTION_RESULT, result.to_dict()]
+    raise ExtractionError(
+        f"Process IPC cannot serialize {type(result).__name__}; only str and ExtractionResult are supported"
+    )
+
+
+def _deserialize_payload(data: object) -> object:
+    """Reconstruct an extraction result from its JSON wire [type_tag, value] pair."""
+    if not isinstance(data, list) or len(data) != 2:  # noqa: PLR2004
+        raise ExtractionError(f"Malformed IPC payload: expected [type, value], got {type(data).__name__}")
+    wire_type, value = data
+    if wire_type == _WIRE_TYPE_STR:
+        if not isinstance(value, str):
+            raise ExtractionError(f"IPC type tag 'str' but value is {type(value).__name__}")
+        return value
+    if wire_type == _WIRE_TYPE_EXTRACTION_RESULT:
+        if not isinstance(value, dict):
+            raise ExtractionError(f"IPC type tag 'ExtractionResult' but value is {type(value).__name__}")
+        return ExtractionResult.from_dict(value)
+    raise ExtractionError(f"Unknown IPC type tag: {wire_type!r}")
+
+
+def _ipc_send(conn: Connection, status: str, payload: object) -> None:
+    """Send a [status, payload] message as JSON bytes over the connection."""
+    if status == "ok":
+        wire_payload = _serialize_payload(payload)
+    else:
+        wire_payload = str(payload)
+    conn.send_bytes(json.dumps([status, wire_payload]).encode("utf-8"))
+
+
 def _process_worker(conn: Connection, fn: Callable[..., object], args: tuple[object, ...]) -> None:
-    """Child-process entry point: run fn and send (status, payload) back."""
+    """Child-process entry point: run fn and send [status, payload] back via JSON."""
     try:
-        conn.send(("ok", fn(*args)))
+        _ipc_send(conn, "ok", fn(*args))
     except BaseException as exc:  # noqa: BLE001 — process boundary: re-raised in parent
-        _send_error(conn, exc)
+        _ipc_send(conn, "err", f"{type(exc).__name__}: {exc}")
     finally:
         conn.close()
 
 
-def _send_error(conn: Connection, exc: BaseException) -> None:
-    """Send the worker's exception, degrading to its string form when needed.
-
-    An exception that fails the pickle round-trip (unpicklable attributes, or
-    an __init__ that pickle cannot replay on load) would either kill this
-    child mid-send or raise out of the parent's recv() — losing the root
-    cause. The round-trip check catches both directions here, where the
-    original message is still available.
-    """
-    try:
-        pickle.loads(pickle.dumps(exc))
-    except Exception:  # noqa: BLE001 — corrective: fall back to string form
-        conn.send(("err", f"{type(exc).__name__}: {exc}"))
-        return
-    conn.send(("err", exc))
-
-
 def _recv_result(parent_conn: Connection, label: str, path: Path) -> tuple[str, object]:
-    """Receive the worker's (status, payload) pair.
+    """Receive the worker's [status, payload] pair via JSON deserialization.
+
+    Uses recv_bytes + json.loads instead of recv (pickle) to prevent a
+    compromised child from achieving code execution in the parent via
+    crafted pickle payloads.
 
     EOFError (child died without sending) propagates to the caller, which
-    distinguishes timeout kills from spontaneous child death. Any other
-    failure is an unpicklable payload and is wrapped in ExtractionError so
-    the CLI batch loop can contain it.
+    distinguishes timeout kills from spontaneous child death.
     """
     try:
-        return parent_conn.recv()
+        raw = parent_conn.recv_bytes()
+        data = json.loads(raw)
+        if not isinstance(data, list) or len(data) != 2:  # noqa: PLR2004
+            raise ExtractionError(f"{label} extraction IPC for {path}: malformed message structure")
+        status, wire_payload = data
+        if status == "ok":
+            return (status, _deserialize_payload(wire_payload))
+        return (status, wire_payload)
     except EOFError:
         raise
+    except ExtractionError:
+        raise
     except Exception as exc:
-        raise ExtractionError(f"{label} extraction result for {path} failed to unpickle: {exc!r}") from exc
+        raise ExtractionError(f"{label} extraction result for {path} failed to decode: {exc!r}") from exc
 
 
 def _kill_process(process: multiprocessing.process.BaseProcess) -> None:
@@ -254,9 +289,7 @@ def _run_in_process[T](
     _reap_process(process)
 
     if status == "err":
-        if not isinstance(payload, BaseException):
-            raise ExtractionError(f"{label} extraction failed for {path}: {payload!r}")
-        raise ExtractionError(f"{label} extraction failed for {path}: {payload}") from payload
+        raise ExtractionError(f"{label} extraction failed for {path}: {payload}")
     if payload is None:
         raise ExtractionError(f"{label} extraction returned no result for {path}")
     return payload

--- a/obsidian_import/timeout.py
+++ b/obsidian_import/timeout.py
@@ -233,6 +233,57 @@ def _reap_process(process: multiprocessing.process.BaseProcess) -> None:
         _kill_process(process)
 
 
+def _recv_with_watchdog(
+    parent_conn: Connection,
+    process: multiprocessing.process.BaseProcess,
+    deadline: float,
+    timeout_seconds: int,
+    label: str,
+    path: Path,
+) -> tuple[str, object]:
+    """Poll for data, receive with a deadline watchdog, and classify failures."""
+    timed_out = threading.Event()
+
+    def _enforce_deadline() -> None:
+        timed_out.set()
+        _kill_process(process)
+
+    if not parent_conn.poll(timeout_seconds):
+        raise _timeout_error(timeout_seconds, label, path)
+
+    # poll() only guarantees the first bytes arrived; recv() blocks until the
+    # full payload streams in. The watchdog kills the child at the deadline so
+    # recv() unblocks with EOFError instead of hanging on a stalled child.
+    watchdog = threading.Timer(max(deadline - time.monotonic(), 0.0), _enforce_deadline)
+    watchdog.start()
+    try:
+        return _recv_result(parent_conn, label, path)
+    except EOFError as exc:
+        if timed_out.is_set():
+            raise _timeout_error(timeout_seconds, label, path) from exc
+        raise ExtractionError(
+            f"{label} extraction process died without a result for {path}. "
+            "If this was called from a script with isolation='process', the call "
+            'must run under an `if __name__ == "__main__":` guard — '
+            "multiprocessing spawn re-imports the calling module in the child."
+        ) from exc
+    finally:
+        watchdog.cancel()
+
+
+def _dispatch_worker_result[T](status: str, payload: object, label: str, path: Path) -> T:
+    """Convert a worker's [status, payload] into the extraction result or raise.
+
+    The err payload is always the child's stringified exception: the JSON wire
+    format cannot carry an exception object, so there is no type to inspect.
+    """
+    if status == "err":
+        raise ExtractionError(f"{label} extraction failed for {path}: {payload}")
+    if payload is None:
+        raise ExtractionError(f"{label} extraction returned no result for {path}")
+    return payload
+
+
 def _run_in_process[T](
     fn: Callable[..., T], args: tuple[object, ...], timeout_seconds: int, label: str, path: Path
 ) -> T:
@@ -248,48 +299,14 @@ def _run_in_process[T](
     process.start()
     child_conn.close()
 
-    timed_out = threading.Event()
-
-    def _enforce_deadline() -> None:
-        timed_out.set()
-        _kill_process(process)
-
     try:
-        try:
-            if not parent_conn.poll(timeout_seconds):
-                raise _timeout_error(timeout_seconds, label, path)
-            # poll() only guarantees the first bytes arrived; recv() blocks
-            # until the full payload streams in. The watchdog kills the child
-            # at the deadline so recv() unblocks with EOFError instead of
-            # hanging on a stalled child.
-            watchdog = threading.Timer(max(deadline - time.monotonic(), 0.0), _enforce_deadline)
-            watchdog.start()
-            try:
-                status, payload = _recv_result(parent_conn, label, path)
-            except EOFError as exc:
-                if timed_out.is_set():
-                    raise _timeout_error(timeout_seconds, label, path) from exc
-                raise ExtractionError(
-                    f"{label} extraction process died without a result for {path}. "
-                    "If this was called from a script with isolation='process', the call "
-                    'must run under an `if __name__ == "__main__":` guard — '
-                    "multiprocessing spawn re-imports the calling module in the child."
-                ) from exc
-            finally:
-                watchdog.cancel()
-        except BaseException:
-            # Timeout, child death, unpicklable payload, or caller interrupt:
-            # never leave a worker behind.
-            if process.is_alive():
-                _kill_process(process)
-            raise
+        status, payload = _recv_with_watchdog(parent_conn, process, deadline, timeout_seconds, label, path)
+    except BaseException:
+        if process.is_alive():
+            _kill_process(process)
+        raise
     finally:
         parent_conn.close()
 
     _reap_process(process)
-
-    if status == "err":
-        raise ExtractionError(f"{label} extraction failed for {path}: {payload}")
-    if payload is None:
-        raise ExtractionError(f"{label} extraction returned no result for {path}")
-    return payload
+    return _dispatch_worker_result(status, payload, label, path)

--- a/pixi.lock
+++ b/pixi.lock
@@ -83,7 +83,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/a7/99dfed167ba728384521acd54fadbb7649ce49333018f42e1f190ed25911/mail_parser-4.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
@@ -99,6 +98,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/40/66/71c1227dff78aaeb942fed29dd5651f2aec166cc7c9aeea3e8b26a539b7d/identify-2.6.17-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/42/42/90e0074fc28be8a35497fc344a17a1e424be487a72838a563e691e16bb29/docling-2.102.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -246,7 +246,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
-      - pypi: https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
@@ -254,6 +253,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/b9/f6ab8918fc15429f79cb04afa9f9913546212d7fb5e5196132a2af46676b/shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl
@@ -1025,10 +1025,10 @@ packages:
   - hypothesis>=6.0,<7 ; extra == 'dev'
   - pytest-cov>=5.0,<6 ; extra == 'dev'
   requires_python: '>=3.12'
-- pypi: https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl
   name: lxml
-  version: 6.0.2
-  sha256: b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe
+  version: 6.1.1
+  sha256: 19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0
   requires_dist:
   - cssselect>=0.7 ; extra == 'cssselect'
   - html5lib ; extra == 'html5'
@@ -1809,10 +1809,10 @@ packages:
   - markupsafe>=2.0.1
   - mkdocs>=1.1
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
   name: lxml
-  version: 6.0.2
-  sha256: 98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d
+  version: 6.1.1
+  sha256: 9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13
   requires_dist:
   - cssselect>=0.7 ; extra == 'cssselect'
   - html5lib ; extra == 'html5'

--- a/pixi.lock
+++ b/pixi.lock
@@ -136,7 +136,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/79/79/98757a1aa32db2222cf22d34c36f651487bdff19e9fee2182485d7200b12/docling_parse-6.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/2c/f0dc4e1ee7f618f5bff7e05898d20bf8b6e7fa612038f768bfa295f136a4/mkdocstrings-0.30.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/46/02ac5e262d4af18054b3e922b2baedbb2a03289ee792162de60a865defc5/accelerate-1.13.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/c0/fcac4b2cf2e64bbebb582635a934b2ebdb5db0017843d9a289c379108bd6/docling_core-2.82.0-py3-none-any.whl
@@ -188,6 +187,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d3/01/a10fe54b653061585e655f5286c2662ebddb68831ed3eaebfb0eb08c0a16/ruff-0.15.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl
@@ -321,7 +321,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7a/42/283909467290b24fdbc29bb32ee20e409a19a55002b43175d66d091ca1a4/tree_sitter_c-0.24.1-cp310-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/2c/f0dc4e1ee7f618f5bff7e05898d20bf8b6e7fa612038f768bfa295f136a4/mkdocstrings-0.30.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/46/02ac5e262d4af18054b3e922b2baedbb2a03289ee792162de60a865defc5/accelerate-1.13.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
@@ -361,6 +360,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz
@@ -2847,15 +2847,6 @@ packages:
   - rich ; extra == 'dev'
   - sagemaker ; extra == 'sagemaker'
   requires_python: '>=3.10.0'
-- pypi: https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl
-  name: pymdown-extensions
-  version: 10.21.3
-  sha256: d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6
-  requires_dist:
-  - markdown>=3.6
-  - pyyaml
-  - pygments>=2.19.1 ; extra == 'extra'
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore
   version: 1.0.9
@@ -3694,6 +3685,15 @@ packages:
   - requests ; extra == 'dev'
   - setuptools ; extra == 'dev'
   - xmlschema ; extra == 'dev'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl
+  name: pymdown-extensions
+  version: 11.0.1
+  sha256: db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2
+  requires_dist:
+  - markdown>=3.6
+  - pyyaml
+  - pygments>=2.19.1 ; extra == 'extra'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl
   name: python-pptx

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,7 +29,7 @@ pytest-cov = ">=5.0,<6"
 pre-commit = ">=4.0,<5"
 mkdocs = ">=1.6,<2"
 mkdocs-material = ">=9.5,<10"
-pymdown-extensions = ">=10.21.3,<11"  # CVE-2026-46338: snippets path traversal
+pymdown-extensions = ">=11.0.0,<12"  # CVE-2026-46338: snippets path traversal; CVE-2026-61632: b64 path traversal
 mkdocstrings = {version = ">=0.29,<1", extras = ["python"]}
 docling = ">=2.94.0,<3"  # CVE-2026-44017/44018/44019/44023/47214: docling/docling-core Zip Slip, XXE, file:// + SSRF (fixed >=2.94.0); PYSEC-2026-139: transitive torch deserialization vuln, no fix as of 2026-05-25; PYSEC-2025-217: transitive transformers X-CLIP RCE, no fix available as of 2026-06-29
 pyasn1 = ">=0.6.4,<1"  # PYSEC-2026-3455/3456/3457: BER tag parsing, OID quadratic decode, Real float DoS

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,8 @@ mkdocs = ">=1.6,<2"
 mkdocs-material = ">=9.5,<10"
 pymdown-extensions = ">=11.0.0,<12"  # CVE-2026-46338: snippets path traversal; CVE-2026-61632: b64 path traversal
 mkdocstrings = {version = ">=0.29,<1", extras = ["python"]}
-docling = ">=2.94.0,<3"  # CVE-2026-44017/44018/44019/44023/47214: docling/docling-core Zip Slip, XXE, file:// + SSRF (fixed >=2.94.0); PYSEC-2026-139: transitive torch deserialization vuln, no fix as of 2026-05-25; PYSEC-2025-217: transitive transformers X-CLIP RCE, no fix available as of 2026-06-29
+docling = ">=2.94.0,<3"  # CVE-2026-44017/44018/44019/44023/47214: docling/docling-core Zip Slip, XXE, file:// + SSRF (fixed >=2.94.0); PYSEC-2026-139: transitive torch deserialization vuln, no fix as of 2026-05-25; PYSEC-2025-217: transitive transformers X-CLIP RCE, no fix available as of 2026-06-29; PYSEC-2026-87: transitive lxml vuln, pinned lxml>=6.1.0 separately
+lxml = ">=6.1.0,<7"  # PYSEC-2026-87: vulnerability fix (transitive dep via docling)
 pyasn1 = ">=0.6.4,<1"  # PYSEC-2026-3455/3456/3457: BER tag parsing, OID quadratic decode, Real float DoS
 jinja2 = ">=3.1.6,<4"
 pyjwt = ">=2.13.0,<3"  # PYSEC-2026-175/177/178/179: algorithm confusion, SSRF

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,13 @@ import pytest
 
 from obsidian_import.config import (
     ImportConfig,
+    _build_backends_config,
     _build_config,
+    _build_extraction_config,
+    _build_input_config,
+    _build_media_config,
+    _build_output_config,
+    _build_passthrough_config,
     _deep_merge,
     _load_default_yaml,
     config_for_backend,
@@ -177,6 +183,188 @@ class TestBuildConfig:
         raw["input"]["directories"] = [{"path": "/tmp", "extensions": [".pdf"]}]
         with pytest.raises(ConfigError, match="missing required key"):
             _build_config(raw, config_dir=None)
+
+
+class TestBuildInputConfig:
+    def test_empty_directories(self):
+        result = _build_input_config({"directories": []})
+        assert result.directories == ()
+
+    def test_valid_directory(self):
+        raw = {"directories": [{"path": "/docs", "extensions": [".pdf", ".docx"], "exclude": ["*.tmp"]}]}
+        result = _build_input_config(raw)
+        assert len(result.directories) == 1
+        assert result.directories[0].path == "/docs"
+        assert result.directories[0].extensions == (".pdf", ".docx")
+        assert result.directories[0].exclude == ("*.tmp",)
+
+    def test_multiple_directories(self):
+        raw = {
+            "directories": [
+                {"path": "/a", "extensions": [".pdf"], "exclude": []},
+                {"path": "/b", "extensions": [".docx"], "exclude": ["~$*"]},
+            ]
+        }
+        result = _build_input_config(raw)
+        assert len(result.directories) == 2
+
+    def test_bare_string_raises(self):
+        with pytest.raises(ConfigError, match="must be a dict"):
+            _build_input_config({"directories": ["/tmp/docs"]})
+
+    def test_missing_extensions_raises(self):
+        with pytest.raises(ConfigError, match="missing required key"):
+            _build_input_config({"directories": [{"path": "/tmp", "exclude": []}]})
+
+    def test_missing_exclude_raises(self):
+        with pytest.raises(ConfigError, match="missing required key"):
+            _build_input_config({"directories": [{"path": "/tmp", "extensions": [".pdf"]}]})
+
+    def test_no_directories_key_defaults_empty(self):
+        result = _build_input_config({})
+        assert result.directories == ()
+
+
+class TestBuildOutputConfig:
+    def test_valid_output(self):
+        raw = {"directory": "./out", "frontmatter": True, "metadata_fields": ["title", "source"]}
+        result = _build_output_config(raw)
+        assert result.directory == "./out"
+        assert result.frontmatter is True
+        assert result.metadata_fields == ("title", "source")
+
+    def test_frontmatter_false(self):
+        raw = {"directory": "/output", "frontmatter": False, "metadata_fields": []}
+        result = _build_output_config(raw)
+        assert result.frontmatter is False
+        assert result.metadata_fields == ()
+
+
+class TestBuildBackendsConfig:
+    def test_all_explicit(self):
+        raw = {
+            "pdf": "native",
+            "docx": "native",
+            "pptx": "native",
+            "xlsx": "native",
+            "csv": "native",
+            "json": "native",
+            "yaml": "native",
+            "image": "native",
+            "html": "markitdown",
+            "default": "native",
+        }
+        result = _build_backends_config(raw)
+        assert result.pdf == "native"
+        assert result.html == "markitdown"
+        assert result.default == "native"
+
+    def test_optional_keys_fall_back_to_default(self):
+        raw = {"pdf": "native", "docx": "native", "pptx": "native", "xlsx": "native", "default": "markitdown"}
+        result = _build_backends_config(raw)
+        assert result.csv == "markitdown"
+        assert result.json == "markitdown"
+        assert result.yaml == "markitdown"
+        assert result.image == "markitdown"
+        assert result.html == "markitdown"
+
+    def test_html_falls_back_to_default(self):
+        raw = {"pdf": "a", "docx": "a", "pptx": "a", "xlsx": "a", "default": "fallback"}
+        result = _build_backends_config(raw)
+        assert result.html == "fallback"
+
+
+class TestBuildExtractionConfig:
+    def test_valid_extraction(self):
+        raw = {"timeout_seconds": 60, "max_file_size_mb": 50, "xlsx_max_rows_per_sheet": 200, "isolation": "thread"}
+        result = _build_extraction_config(raw)
+        assert result.timeout_seconds == 60
+        assert result.max_file_size_mb == 50
+        assert result.xlsx_max_rows_per_sheet == 200
+        assert result.isolation == "thread"
+
+    def test_values_cast_to_int(self):
+        raw = {
+            "timeout_seconds": "90",
+            "max_file_size_mb": "75",
+            "xlsx_max_rows_per_sheet": "300",
+            "isolation": "process",
+        }
+        result = _build_extraction_config(raw)
+        assert result.timeout_seconds == 90
+        assert result.max_file_size_mb == 75
+
+    def test_invalid_isolation_raises(self):
+        raw = {"timeout_seconds": 60, "max_file_size_mb": 50, "xlsx_max_rows_per_sheet": 200, "isolation": "fiber"}
+        with pytest.raises(ConfigError, match="isolation"):
+            _build_extraction_config(raw)
+
+
+class TestBuildPassthroughConfig:
+    def test_empty_passthrough(self):
+        result = _build_passthrough_config({})
+        assert result.extensions == ()
+        assert result.paths == ()
+        assert result.patterns == ()
+
+    def test_valid_passthrough(self):
+        raw = {"extensions": [".md", ".canvas"], "paths": ["raw/**"], "patterns": [r".*\.gen\..*"]}
+        result = _build_passthrough_config(raw)
+        assert result.extensions == (".md", ".canvas")
+        assert result.paths == ("raw/**",)
+        assert len(result.patterns) == 1
+
+    def test_invalid_regex_raises(self):
+        with pytest.raises(ConfigError, match="Invalid regex"):
+            _build_passthrough_config({"patterns": ["[invalid"]})
+
+    def test_multiple_patterns_validated(self):
+        raw = {"patterns": [r"ok_pattern", "[bad"]}
+        with pytest.raises(ConfigError, match="Invalid regex"):
+            _build_passthrough_config(raw)
+
+
+class TestBuildMediaConfig:
+    def test_valid_media(self):
+        raw = {
+            "extract_images": True,
+            "image_format": "png",
+            "image_max_dimension": 1024,
+            "image_max_bytes": 5000000,
+            "image_max_pixels": 5000000,
+            "image_allowed_formats": ["PNG", "JPEG"],
+        }
+        result = _build_media_config(raw)
+        assert result.extract_images is True
+        assert result.image_format == "png"
+        assert result.image_max_dimension == 1024
+        assert result.image_allowed_formats == frozenset({"PNG", "JPEG"})
+
+    def test_extract_images_false(self):
+        raw = {
+            "extract_images": False,
+            "image_format": "jpeg",
+            "image_max_dimension": 0,
+            "image_max_bytes": 1000,
+            "image_max_pixels": 1000,
+            "image_allowed_formats": [],
+        }
+        result = _build_media_config(raw)
+        assert result.extract_images is False
+        assert result.image_allowed_formats == frozenset()
+
+    def test_values_cast_to_int(self):
+        raw = {
+            "extract_images": 1,
+            "image_format": "png",
+            "image_max_dimension": "512",
+            "image_max_bytes": "1000",
+            "image_max_pixels": "2000",
+            "image_allowed_formats": ["PNG"],
+        }
+        result = _build_media_config(raw)
+        assert result.image_max_dimension == 512
+        assert result.image_max_bytes == 1000
 
 
 class TestLoadConfig:

--- a/tests/test_extraction_result.py
+++ b/tests/test_extraction_result.py
@@ -1,0 +1,53 @@
+"""Tests for ExtractionResult and MediaFile dict serialization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from obsidian_import.extraction_result import ExtractionResult, MediaFile
+
+
+class TestMediaFileDictRoundTrip:
+    def test_round_trip(self) -> None:
+        mf = MediaFile(source_path=Path("/tmp/img.png"), filename="img.png", media_type="image/png")
+        assert MediaFile.from_dict(mf.to_dict()) == mf
+
+    def test_to_dict_values(self) -> None:
+        mf = MediaFile(source_path=Path("/a/b.jpg"), filename="b.jpg", media_type="image/jpeg")
+        d = mf.to_dict()
+        assert d == {"source_path": "/a/b.jpg", "filename": "b.jpg", "media_type": "image/jpeg"}
+
+    @given(
+        filename=st.text(min_size=1, max_size=50).filter(lambda s: "\x00" not in s),
+        media_type=st.sampled_from(["image/png", "image/jpeg", "image/gif", "image/webp"]),
+    )
+    def test_round_trip_property(self, filename: str, media_type: str) -> None:
+        mf = MediaFile(source_path=Path(f"/tmp/{filename}"), filename=filename, media_type=media_type)
+        assert MediaFile.from_dict(mf.to_dict()) == mf
+
+
+class TestExtractionResultDictRoundTrip:
+    def test_round_trip_empty_media(self) -> None:
+        er = ExtractionResult(markdown="# Hello", media_files=())
+        assert ExtractionResult.from_dict(er.to_dict()) == er
+
+    def test_round_trip_with_media(self) -> None:
+        mf = MediaFile(source_path=Path("/tmp/img.png"), filename="img.png", media_type="image/png")
+        er = ExtractionResult(markdown="# Doc\n\n![[img.png]]", media_files=(mf,))
+        assert ExtractionResult.from_dict(er.to_dict()) == er
+
+    def test_to_dict_structure(self) -> None:
+        mf = MediaFile(source_path=Path("/x.png"), filename="x.png", media_type="image/png")
+        er = ExtractionResult(markdown="md", media_files=(mf,))
+        d = er.to_dict()
+        assert d["markdown"] == "md"
+        assert len(d["media_files"]) == 1
+        assert d["media_files"][0]["filename"] == "x.png"
+
+    @given(markdown=st.text(min_size=0, max_size=200))
+    def test_round_trip_property(self, markdown: str) -> None:
+        er = ExtractionResult(markdown=markdown, media_files=())
+        assert ExtractionResult.from_dict(er.to_dict()) == er

--- a/tests/test_ipc_codec.py
+++ b/tests/test_ipc_codec.py
@@ -1,0 +1,135 @@
+"""Tests for the JSON wire codec used by the parent/child extraction IPC."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+from pathlib import Path
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from obsidian_import.exceptions import ExtractionError
+from obsidian_import.extraction_result import ExtractionResult, MediaFile
+from obsidian_import.ipc_codec import (
+    WIRE_TYPE_EXTRACTION_RESULT,
+    WIRE_TYPE_STR,
+    deserialize_payload,
+    is_envelope,
+    send_message,
+    serialize_payload,
+)
+
+
+class TestIsEnvelope:
+    def test_two_element_list_is_envelope(self) -> None:
+        assert is_envelope(["ok", "payload"])
+
+    @pytest.mark.parametrize("data", [None, "ok", 42, {"status": "ok"}, [], ["ok"], ["ok", 1, 2]])
+    def test_other_shapes_are_not(self, data: object) -> None:
+        assert not is_envelope(data)
+
+
+class TestSerializePayload:
+    def test_str_is_tagged(self) -> None:
+        assert serialize_payload("hello") == [WIRE_TYPE_STR, "hello"]
+
+    def test_extraction_result_is_tagged_as_dict(self) -> None:
+        result = ExtractionResult(markdown="# Doc", media_files=())
+        tag, value = serialize_payload(result)
+        assert tag == WIRE_TYPE_EXTRACTION_RESULT
+        assert value == result.to_dict()
+
+    @pytest.mark.parametrize("unsupported", [None, 42, 1.5, b"bytes", ["a"], {"k": "v"}, Path("/tmp/f")])
+    def test_unsupported_type_raises(self, unsupported: object) -> None:
+        with pytest.raises(ExtractionError, match="cannot serialize"):
+            serialize_payload(unsupported)
+
+    def test_error_names_the_offending_type(self) -> None:
+        with pytest.raises(ExtractionError, match="NoneType"):
+            serialize_payload(None)
+
+
+class TestDeserializePayload:
+    def test_str_round_trip(self) -> None:
+        assert deserialize_payload(serialize_payload("hello")) == "hello"
+
+    def test_extraction_result_round_trip(self) -> None:
+        media = MediaFile(source_path=Path("/tmp/i.png"), filename="i.png", media_type="image/png")
+        result = ExtractionResult(markdown="# Doc\n\n![[i.png]]", media_files=(media,))
+        assert deserialize_payload(serialize_payload(result)) == result
+
+    @pytest.mark.parametrize("bad", ["bare", 42, None, {"type": "str"}, [], [WIRE_TYPE_STR]])
+    def test_non_envelope_raises(self, bad: object) -> None:
+        with pytest.raises(ExtractionError, match="Malformed IPC payload"):
+            deserialize_payload(bad)
+
+    def test_unknown_tag_raises(self) -> None:
+        with pytest.raises(ExtractionError, match="Unknown IPC type tag"):
+            deserialize_payload(["SomethingElse", {}])
+
+    def test_str_tag_with_non_str_value_raises(self) -> None:
+        with pytest.raises(ExtractionError, match="type tag 'str' but value is int"):
+            deserialize_payload([WIRE_TYPE_STR, 42])
+
+    def test_extraction_result_tag_with_non_dict_value_raises(self) -> None:
+        with pytest.raises(ExtractionError, match="type tag 'ExtractionResult' but value is str"):
+            deserialize_payload([WIRE_TYPE_EXTRACTION_RESULT, "not a dict"])
+
+
+class TestPayloadRoundTripProperties:
+    @given(value=st.text(max_size=200))
+    def test_str_round_trips(self, value: str) -> None:
+        assert deserialize_payload(serialize_payload(value)) == value
+
+    @given(markdown=st.text(max_size=200), filenames=st.lists(st.text(min_size=1, max_size=30), max_size=5))
+    def test_extraction_result_round_trips(self, markdown: str, filenames: list[str]) -> None:
+        media = tuple(
+            MediaFile(source_path=Path("/tmp") / name, filename=name, media_type="image/png") for name in filenames
+        )
+        result = ExtractionResult(markdown=markdown, media_files=media)
+        assert deserialize_payload(serialize_payload(result)) == result
+
+    @given(value=st.text(max_size=200))
+    def test_wire_form_is_json_encodable(self, value: str) -> None:
+        """The whole point of the codec: every payload survives a JSON round trip."""
+        wire = serialize_payload(value)
+        assert deserialize_payload(json.loads(json.dumps(wire))) == value
+
+
+class TestSendMessage:
+    def test_ok_message_carries_serialized_payload(self) -> None:
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+        send_message(child_conn, "ok", "extracted")
+        child_conn.close()
+        status, wire_payload = json.loads(parent_conn.recv_bytes())
+        parent_conn.close()
+        assert status == "ok"
+        assert deserialize_payload(wire_payload) == "extracted"
+
+    def test_err_message_stringifies_payload(self) -> None:
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+        send_message(child_conn, "err", "ValueError: bad input")
+        child_conn.close()
+        status, wire_payload = json.loads(parent_conn.recv_bytes())
+        parent_conn.close()
+        assert status == "err"
+        assert wire_payload == "ValueError: bad input"
+
+    def test_err_payload_needs_no_serializable_type(self) -> None:
+        """An err payload bypasses serialize_payload, so any object is accepted."""
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+        send_message(child_conn, "err", ValueError("boom"))
+        child_conn.close()
+        status, wire_payload = json.loads(parent_conn.recv_bytes())
+        parent_conn.close()
+        assert status == "err"
+        assert wire_payload == "boom"
+
+    def test_unserializable_ok_payload_raises(self) -> None:
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+        with pytest.raises(ExtractionError, match="cannot serialize"):
+            send_message(child_conn, "ok", object())
+        child_conn.close()
+        parent_conn.close()

--- a/tests/test_timeout_escalation.py
+++ b/tests/test_timeout_escalation.py
@@ -100,7 +100,7 @@ class TestWatchdogRaceDuringRecv:
         mock_ctx.Pipe.return_value = (mock_parent, mock_child)
         mock_ctx.Process.return_value = mock_process
         mock_parent.poll.return_value = True
-        mock_parent.recv.side_effect = EOFError("pipe closed")
+        mock_parent.recv_bytes.side_effect = EOFError("pipe closed")
 
         with (
             patch("obsidian_import.timeout.multiprocessing.get_context", return_value=mock_ctx),

--- a/tests/test_timeout_process.py
+++ b/tests/test_timeout_process.py
@@ -5,6 +5,7 @@ The worker functions are module-level so the spawn context can pickle them.
 
 from __future__ import annotations
 
+import json
 import multiprocessing
 import os
 import subprocess
@@ -88,17 +89,6 @@ def _exit_without_sending() -> str:
     os._exit(0)
 
 
-def _boom_on_load() -> None:
-    raise TypeError("unpickle boom")
-
-
-class _EvilPayload:
-    """Pickles fine; raises TypeError when unpickled on the receiving side."""
-
-    def __reduce__(self) -> tuple[object, tuple[object, ...]]:
-        return (_boom_on_load, ())
-
-
 def _child_pids() -> set[int]:
     """PIDs of direct children of this process, via os-level ps (psutil is not a dep).
 
@@ -124,7 +114,7 @@ class TestRunWithTimeoutProcess:
         )
         assert result == "hello"
 
-    def test_extraction_result_survives_pickling(self, tmp_path: Path) -> None:
+    def test_extraction_result_survives_json_ipc(self, tmp_path: Path) -> None:
         path = tmp_path / "f.pdf"
         path.write_text("x")
         result = run_with_timeout(
@@ -143,7 +133,8 @@ class TestRunWithTimeoutProcess:
                 (),
                 TimeoutContext(timeout_seconds=30, label="test", path=path, isolation="process"),
             )
-        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "ValueError" in str(exc_info.value)
+        assert "bad input from child" in str(exc_info.value)
 
     def test_timeout_raises_and_kills_child_process(self, tmp_path: Path) -> None:
         """A timed-out extraction process must be killed — no zombie, no survivor."""
@@ -230,13 +221,68 @@ class TestRunWithTimeoutProcess:
             )
         assert "UnpicklableError" in str(exc_info.value)
 
-    def test_recv_unpickle_failure_wrapped_as_extraction_error(self) -> None:
-        """Parent-side defense: a payload that fails to unpickle out of the pipe
-        is wrapped in ExtractionError instead of escaping as TypeError."""
+    def test_recv_invalid_json_wrapped_as_extraction_error(self) -> None:
+        """Parent-side defense: non-JSON bytes are wrapped in ExtractionError."""
         parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
-        child_conn.send(("err", _EvilPayload()))
+        child_conn.send_bytes(b"not valid json {{{")
         child_conn.close()
-        with pytest.raises(ExtractionError, match="unpickle"):
+        with pytest.raises(ExtractionError, match="failed to decode"):
+            _recv_result(parent_conn, "test", Path("/tmp/f.txt"))
+        parent_conn.close()
+
+    def test_recv_malformed_json_structure_raises_extraction_error(self) -> None:
+        """A valid JSON value that is not [status, payload] is rejected."""
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+        child_conn.send_bytes(json.dumps({"unexpected": "object"}).encode("utf-8"))
+        child_conn.close()
+        with pytest.raises(ExtractionError, match="malformed"):
+            _recv_result(parent_conn, "test", Path("/tmp/f.txt"))
+        parent_conn.close()
+
+    def test_recv_pickle_bytes_rejected(self) -> None:
+        """Raw pickle bytes from a compromised child must not be deserialized."""
+        import pickle
+
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+        child_conn.send_bytes(pickle.dumps(("ok", "injected")))
+        child_conn.close()
+        with pytest.raises(ExtractionError, match="failed to decode"):
+            _recv_result(parent_conn, "test", Path("/tmp/f.txt"))
+        parent_conn.close()
+
+    def test_recv_unknown_type_tag_raises_extraction_error(self) -> None:
+        """A JSON payload with an unknown type tag is rejected."""
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+        child_conn.send_bytes(json.dumps(["ok", ["UnknownType", {}]]).encode("utf-8"))
+        child_conn.close()
+        with pytest.raises(ExtractionError, match="Unknown IPC type tag"):
+            _recv_result(parent_conn, "test", Path("/tmp/f.txt"))
+        parent_conn.close()
+
+    def test_recv_str_type_with_non_string_value_raises(self) -> None:
+        """A type tag of 'str' with a non-string value is rejected."""
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+        child_conn.send_bytes(json.dumps(["ok", ["str", 42]]).encode("utf-8"))
+        child_conn.close()
+        with pytest.raises(ExtractionError, match="type tag 'str' but value is"):
+            _recv_result(parent_conn, "test", Path("/tmp/f.txt"))
+        parent_conn.close()
+
+    def test_recv_extraction_result_type_with_non_dict_raises(self) -> None:
+        """A type tag of 'ExtractionResult' with a non-dict value is rejected."""
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+        child_conn.send_bytes(json.dumps(["ok", ["ExtractionResult", "not a dict"]]).encode("utf-8"))
+        child_conn.close()
+        with pytest.raises(ExtractionError, match="type tag 'ExtractionResult' but value is"):
+            _recv_result(parent_conn, "test", Path("/tmp/f.txt"))
+        parent_conn.close()
+
+    def test_recv_malformed_payload_not_list_raises(self) -> None:
+        """A JSON payload where the result is not a [type, value] list is rejected."""
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
+        child_conn.send_bytes(json.dumps(["ok", "bare_string"]).encode("utf-8"))
+        child_conn.close()
+        with pytest.raises(ExtractionError, match="Malformed IPC payload"):
             _recv_result(parent_conn, "test", Path("/tmp/f.txt"))
         parent_conn.close()
 
@@ -255,7 +301,7 @@ class TestRunWithTimeoutProcess:
     def test_none_result_raises_extraction_error(self, tmp_path: Path) -> None:
         path = tmp_path / "f.csv"
         path.write_text("x")
-        with pytest.raises(ExtractionError, match="returned no result"):
+        with pytest.raises(ExtractionError, match="cannot serialize NoneType"):
             run_with_timeout(
                 _return_none,
                 (),


### PR DESCRIPTION
Consolidates five open PRs into one branch so they can be reviewed and merged together, instead of each one racing the others for `pixi.lock` and `timeout.py`.

## Why

Five of the eight open PRs were small, independently-authored agent changes sitting against three different bases. Two of them (#280, #288) both rewrite `_run_in_process` in `timeout.py`, so whichever merged first would leave the other conflicted. Merging them as a stack resolves that interaction once, here, rather than three more times on the individual PRs.

## What's included

| PR | Change |
|----|--------|
| #288 | Replace pickle IPC with a JSON wire format, so a compromised child process cannot execute code in the parent |
| #280 | Extract `_recv_with_watchdog` / `_dispatch_worker_result` from `_run_in_process` (CC=9) |
| #279 | Extract per-section sub-builders from `_build_config()` (83 lines) |
| #278 | Extract metadata/form-field/slide helpers from `_extract_pdf()` and `_extract_pptx()` |
| #285 | Pin `pymdown-extensions >=11.0.0` for CVE-2026-61632 (b64 path traversal) |
| #261 | Pin `lxml >=6.1.0` for PYSEC-2026-87 (transitive via docling) |

## Conflicts resolved during consolidation

**`timeout.py` — #288 vs #280.** #280 lifts the trailing result-dispatch out of `_run_in_process` into `_dispatch_worker_result`; #288 simplifies that same dispatch, because a JSON payload can no longer be an exception object. Resolved by keeping #280's structure with #288's simplified body — the `isinstance(payload, BaseException)` branch and its `raise ... from payload` are gone, since the err payload is now always the child's stringified exception.

**`pixi.toml` — #261 vs merged #284.** #261 was branched before `pyasn1` was bumped to `>=0.6.4`, so its diff would have reverted that. Kept `>=0.6.4` and applied only the `lxml` pin.

## One change beyond the original PRs

`timeout.py` was 295 lines with #288 alone and 275 with #280 alone. Stacked, it hits **312** — past the 300-line ceiling in `CLAUDE.md`, a limit neither PR crossed by itself. Rather than ship a known violation, the JSON wire format moved into a new `obsidian_import/ipc_codec.py` (58 lines), leaving `timeout.py` at **271** with only isolation and process lifecycle. The wire format and every error message are unchanged, so #288's IPC tests still pin the same behavior; the new module gets its own unit and hypothesis round-trip tests.

## Deliberately excluded

**#262 (`transformers >=5.3.0`, CVE-2026-4372 / CVE-2026-1839) is not included.** Its `pixi.lock` is a full re-resolve against a base from July 6th — 1,274 of its changed lock lines are unrelated to `transformers`, and applying them would revert lock state from `main` (e.g. downgrade `pillow` 12.3.0 → 12.2.0). Correctly rebasing it needs `pixi lock` re-run against current `main`, and this environment's network policy blocks `pixi.sh` and `conda-forge`, so the lock cannot be regenerated here. **#262 should stay open and be rebased in an environment with pixi available.**

**#243 (`chore(main): release 1.2.2`)** is release-please-managed and left untouched.

## A note on the `lxml` lock entries

`pixi.lock` could not be regenerated here for the reason above, so #261's `lxml` entries were transplanted onto the current lock rather than re-resolved: the two 6.0.2 wheel entries were replaced with the 6.1.1 wheels from #261's own pixi-generated lock, and nothing else from that stale lock was applied. Both wheel hashes were verified against PyPI directly:

```
9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13  lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0  lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl
```

`lxml` has no dependencies of its own and `docling` is at the same 2.102.2 in both locks, so 6.1.1 is the same resolution #261 got. **CI's `pixi install` is the real gate on this** — the entries sit in URL-sorted position in the environment lists, but the `packages:` blocks were left where they were, so a future `pixi lock` may reorder them cosmetically. If CI rejects the lock, drop commit `1aa78d7` and let #261 be rebased with pixi instead.

## Verification

Ran locally on Python 3.13 (`uv venv` + `pip install -e ".[dev]"`, since pixi is unavailable here):

- **481 passed**, 98% coverage (threshold 80%); `ipc_codec.py` at 100%
- `ruff check` and `ruff format --check` clean across 62 files
- `tests/test_docling_extract.py` (13 tests) excluded locally — `docling` is a pixi-only dependency, not in the `[dev]` extra. Confirmed these same 13 fail identically on unmodified `origin/main`, so the gap is environmental, not a regression. CI runs them under pixi.

Once this merges, #278, #279, #280, #285 and #288 can be closed as superseded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QS8rVGrsE3BebdSZyW7T4L)_