### PR TITLE
Add PR branch sync workflow and pixi.lock merge strategy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# pixi.lock is solver output. Text-merging two resolutions produces a lockfile
+# that parses but no longer describes a solvable environment, so refuse the merge
+# and let it be regenerated with `pixi lock` instead.
+pixi.lock -merge linguist-generated=true

--- a/.github/workflows/pr-branch-sync.yml
+++ b/.github/workflows/pr-branch-sync.yml
@@ -1,0 +1,122 @@
+name: PR Branch Sync
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "30 5 * * *" # Daily 05:30 UTC, catches PRs missed by push runs
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to sync (blank syncs every open claude/* PR)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-branch-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Merge main into open PR branches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.FACTORY_PAT }}
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.8
+        with:
+          cache: true
+          locked: false
+          run-install: false
+
+      - name: Merge main and relock conflicted branches
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_PAT }}
+          REPO: ${{ github.repository }}
+          PR_INPUT: ${{ inputs.pr }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GIT_EDITOR: "true"
+          MARKER: "<!-- factory:pr-branch-sync -->"
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin main
+          BASE_SHA=$(git rev-parse origin/main)
+
+          if [ -n "$PR_INPUT" ]; then
+            PR_NUMBERS="$PR_INPUT"
+          else
+            PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --base main \
+              --json number,headRefName,isCrossRepository \
+              --jq '.[] | select(.isCrossRepository == false)
+                        | select(.headRefName | startswith("claude/")) | .number')
+          fi
+
+          if [ -z "$PR_NUMBERS" ]; then
+            echo "No open claude/* PRs to sync."
+            exit 0
+          fi
+
+          for PR in $PR_NUMBERS; do
+            BRANCH=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq '.headRefName')
+            echo "::group::PR #$PR ($BRANCH)"
+
+            git reset --hard
+            git fetch origin "$BRANCH"
+            git checkout -f -B "$BRANCH" "origin/$BRANCH"
+
+            if git merge-base --is-ancestor "$BASE_SHA" HEAD; then
+              echo "Branch already contains main ($BASE_SHA). Nothing to do."
+              echo "::endgroup::"
+              continue
+            fi
+
+            if ! git merge --no-edit origin/main; then
+              CONFLICTS=$(git diff --name-only --diff-filter=U)
+              if [ "$CONFLICTS" != "pixi.lock" ]; then
+                git merge --abort
+                echo "::warning::PR #$PR has conflicts outside pixi.lock, needs a human: $CONFLICTS"
+                BODY=$(printf '%s\n\n%s\n\n%s\n\n%s\n' \
+                  "$MARKER" \
+                  "This branch conflicts with \`main\` in files the sync workflow will not resolve automatically:" \
+                  "$(echo "$CONFLICTS" | sed 's/^/- `/;s/$/`/')" \
+                  "Merge \`main\` in manually, then run \`pixi lock\` to refresh \`pixi.lock\`. ([sync run]($RUN_URL))")
+                COMMENT_ID=$(gh api "repos/$REPO/issues/$PR/comments" \
+                  --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+                if [ -n "$COMMENT_ID" ]; then
+                  gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body="$BODY" >/dev/null
+                else
+                  gh pr comment "$PR" --repo "$REPO" --body "$BODY"
+                fi
+                echo "::endgroup::"
+                continue
+              fi
+
+              # pixi.lock is solver output, never hand-merged: take main's copy and
+              # let pixi re-resolve it against the merged pixi.toml below.
+              git checkout origin/main -- pixi.lock
+              git add pixi.lock
+              git merge --continue
+              echo "Resolved pixi.lock conflict from main; relocking."
+            fi
+
+            pixi lock
+            git add pixi.lock
+            git diff --cached --quiet || git commit -m "chore: relock pixi.lock after merging main"
+
+            git push origin "HEAD:refs/heads/$BRANCH"
+            echo "Synced PR #$PR with main."
+            echo "::endgroup::"
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,8 @@ Stop and request human confirmation before:
 - Primary: pixi (conda-forge + PyPI)
 - Lockfile: pixi.lock
 - Audit: `pip audit` (run inside pixi shell)
+- Never hand-merge `pixi.lock` -- `.gitattributes` marks it unmergeable, so conflicts are whole-file. Take `main`'s copy and regenerate with `pixi lock`.
+- The PR Branch Sync workflow does this automatically for open `claude/*` PRs: merges `main`, resolves `pixi.lock` conflicts, relocks, and pushes.
 
 ### Security Standards
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -177,7 +177,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/7a/a8f5e0561702b25239846a16349feece59712ae20598ebb205580332a471/regex-2026.2.28-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -203,6 +202,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/26/387eca0137a3507ea62acedd2b2903697223cbca2f8561f7c63b47ec3ad2/rapidocr-3.8.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -354,7 +354,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl
@@ -378,6 +377,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f3/26/387eca0137a3507ea62acedd2b2903697223cbca2f8561f7c63b47ec3ad2/rapidocr-3.8.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/cf/2710b6fd6b07ea0aef317b29f335790ba6adf06a28ac236078ed9bd8a91d/rtree-1.4.1-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/62/d9ba6323b9202dd2fe166beab8a86d29465c41a0288cbe229fac60c1ab8d/jsonlines-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/95/12d226ee4d207cb1f77a216baa7e1a8bae2639733c140abe8d0316d23a18/semchunk-3.2.5-py3-none-any.whl
@@ -3563,13 +3563,6 @@ packages:
   - tzdata>=2025.3 ; (sys_platform == 'emscripten' and extra == 'all') or (sys_platform == 'win32' and extra == 'all')
   - watchdog>=4.0.0 ; extra == 'all'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
-  name: pygments
-  version: 2.19.2
-  sha256: 86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b
-  requires_dist:
-  - colorama>=0.4.6 ; extra == 'windows-terminal'
-  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/c7/7a/a8f5e0561702b25239846a16349feece59712ae20598ebb205580332a471/regex-2026.2.28-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: regex
   version: 2026.2.28
@@ -4102,6 +4095,13 @@ packages:
   - opt-einsum>=3.3 ; extra == 'opt-einsum'
   - pyyaml ; extra == 'pyyaml'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
+  name: pygments
+  version: 2.20.0
+  sha256: 81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+  requires_dist:
+  - colorama>=0.4.6 ; extra == 'windows-terminal'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
   name: nvidia-nvjitlink-cu12
   version: 12.8.93

--- a/pixi.lock
+++ b/pixi.lock
@@ -77,7 +77,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/20/14/1db1729ad6db4999c3a16c47937d601fcb909aaa4224f5eca5a2f145a605/mpire-2.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl
@@ -157,6 +156,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
@@ -266,7 +266,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/14/1db1729ad6db4999c3a16c47937d601fcb909aaa4224f5eca5a2f145a605/mpire-2.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/a7/99dfed167ba728384521acd54fadbb7649ce49333018f42e1f190ed25911/mail_parser-4.4.0-py3-none-any.whl
@@ -338,6 +337,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl
@@ -1714,18 +1714,6 @@ packages:
   version: 0.0.4
   sha256: 571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
-  name: requests
-  version: 2.32.5
-  sha256: 2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6
-  requires_dist:
-  - charset-normalizer>=2,<4
-  - idna>=2.5,<4
-  - urllib3>=1.21.1,<3
-  - certifi>=2017.4.17
-  - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
-  - chardet>=3.0.2,<6 ; extra == 'use-chardet-on-py3'
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: nvidia-cufft-cu12
   version: 11.3.3.83
@@ -3198,6 +3186,18 @@ packages:
   requires_dist:
   - dill>=0.4.1
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+  name: requests
+  version: 2.34.2
+  sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+  requires_dist:
+  - charset-normalizer>=2,<4
+  - idna>=2.5,<4
+  - urllib3>=1.26,<3
+  - certifi>=2023.5.7
+  - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
+  - chardet>=3.0.2,<8 ; extra == 'use-chardet-on-py3'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
   name: sympy
   version: 1.14.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ mkdocs = ">=1.6,<2"
 mkdocs-material = ">=9.5,<10"
 pymdown-extensions = ">=11.0.0,<12"  # CVE-2026-46338: snippets path traversal; CVE-2026-61632: b64 path traversal
 mkdocstrings = {version = ">=0.29,<1", extras = ["python"]}
-docling = ">=2.94.0,<3"  # CVE-2026-44017/44018/44019/44023/47214: docling/docling-core Zip Slip, XXE, file:// + SSRF (fixed >=2.94.0); PYSEC-2026-139: transitive torch deserialization vuln, no fix as of 2026-05-25; PYSEC-2025-217: transitive transformers X-CLIP RCE, no fix available as of 2026-06-29; PYSEC-2026-87: transitive lxml vuln, pinned lxml>=6.1.0 separately
+docling = ">=2.94.0,<3"  # CVE-2026-44017/44018/44019/44023/47214: docling/docling-core Zip Slip, XXE, file:// + SSRF (fixed >=2.94.0); PYSEC-2026-139: transitive torch deserialization vuln, no fix as of 2026-05-25; PYSEC-2025-217: transitive transformers X-CLIP RCE, no fix available as of 2026-06-29; PYSEC-2026-87: transitive lxml vuln, pinned lxml>=6.1.0 separately; PYSEC-2025-194: transitive torch deserialization/execution vuln, pinned torch>=2.13.0 on linux-64 separately
 lxml = ">=6.1.0,<7"  # PYSEC-2026-87: vulnerability fix (transitive dep via docling)
 pyasn1 = ">=0.6.4,<1"  # PYSEC-2026-3455/3456/3457: BER tag parsing, OID quadratic decode, Real float DoS
 jinja2 = ">=3.1.6,<4"
@@ -43,6 +43,9 @@ pydantic-settings = ">=2.14.2,<3"  # GHSA-4xgf-cpjx-pc3j: symlink path traversal
 requests = ">=2.33.0,<3"  # PYSEC-2026-2275: moderate-high severity, fix available in 2.33.0
 soupsieve = ">=2.8.4,<3"  # CVE-2026-49477/49476: ReDoS and memory exhaustion
 pygments = ">=2.20.0,<3"  # PYSEC-2026-2987: vulnerability fix
+
+[target.linux-64.pypi-dependencies]
+torch = ">=2.13.0"  # PYSEC-2025-194: deserialization/execution path vuln (transitive via docling; no osx-arm64 wheel for macOS <14)
 
 [tasks]
 lint = "ruff check obsidian_import/ tests/"

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,6 +40,7 @@ urllib3 = ">=2.7.0,<3"
 pyopenssl = ">=26.0.0,<27"
 cryptography = ">=48.0.1,<49"  # GHSA-537c-gmf6-5ccf: bundled OpenSSL vuln
 pydantic-settings = ">=2.14.2,<3"  # GHSA-4xgf-cpjx-pc3j: symlink path traversal in NestedSecretsSettingsSource
+requests = ">=2.33.0,<3"  # PYSEC-2026-2275: moderate-high severity, fix available in 2.33.0
 soupsieve = ">=2.8.4,<3"  # CVE-2026-49477/49476: ReDoS and memory exhaustion
 pygments = ">=2.20.0,<3"  # PYSEC-2026-2987: vulnerability fix
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,6 +41,7 @@ pyopenssl = ">=26.0.0,<27"
 cryptography = ">=48.0.1,<49"  # GHSA-537c-gmf6-5ccf: bundled OpenSSL vuln
 pydantic-settings = ">=2.14.2,<3"  # GHSA-4xgf-cpjx-pc3j: symlink path traversal in NestedSecretsSettingsSource
 soupsieve = ">=2.8.4,<3"  # CVE-2026-49477/49476: ReDoS and memory exhaustion
+pygments = ">=2.20.0,<3"  # PYSEC-2026-2987: vulnerability fix
 
 [tasks]
 lint = "ruff check obsidian_import/ tests/"


### PR DESCRIPTION
## Summary

Adds automated synchronization of open `claude/*` PR branches with `main`, plus infrastructure to prevent hand-merging of `pixi.lock`. Also consolidates the three open dep-audit PRs, which each conflicted on `pixi.lock` — the problem this workflow exists to solve.

## Supersedes

Combines and replaces (close these once this merges):

- #293 — `pygments >= 2.20.0` (PYSEC-2026-2987)
- #294 — `requests >= 2.33.0` (PYSEC-2026-2275)
- #295 — `torch >= 2.13.0` on linux-64 (PYSEC-2025-194)

All three were branched off an older `main`; the pins here are re-applied on top of current `main`.

## Known gap: `pixi.lock` is one pin behind `pixi.toml`

The lock carries the pygments and requests resolutions but **not** the torch one. #295's lock update swaps the entire CUDA stack (`nvidia-*-cu12` → `cuda-*` 13.x) and conflicted with `main`'s newer lock in six regions. `pixi.lock` is solver output, so rather than hand-splice those regions this PR takes `main`'s consistent lock for that commit and leaves regeneration to the tool that owns the file.

CI uses `locked: false`, so lint and tests resolve at install time and are unaffected. To close the gap, either:

- merge this PR, then let the push-to-`main` trigger (or a manual dispatch) of the new PR Branch Sync workflow relock the file, or
- run `pixi lock` on this branch and push the result.

## Changes

- **New workflow: `.github/workflows/pr-branch-sync.yml`**
  - Runs on push to `main`, daily schedule (05:30 UTC), and manual dispatch (optionally for a single PR number)
  - Merges `main` into every open, non-fork `claude/*` PR branch
  - Resolves a `pixi.lock` conflict by taking `main`'s copy and regenerating with `pixi lock`
  - Leaves conflicts in any other file untouched and reports them as a sticky PR comment, so scheduled runs don't spam
  - Pushes with `FACTORY_PAT`, matching `release.yml`'s existing `update-lockfile` job, so CI re-runs afterward

- **New `.gitattributes`**
  - Marks `pixi.lock -merge` so conflicts are whole-file instead of interleaved, and `linguist-generated=true`
  - This is what makes the rest safe: git was previously text-merging two independent solver outputs into a lockfile that parses but no longer describes a solvable environment

- **`pixi.toml`**: the three security pins above, with `torch` under `[target.linux-64.pypi-dependencies]` (no osx-arm64 wheel for macOS < 14)

- **`CLAUDE.md`**: documents that `pixi.lock` is never hand-merged, and what the workflow does

## Verification

The conflict-resolution sequence was exercised in a scratch repository rather than assumed: a lock-only conflict produces a clean whole-file conflict with `pixi.toml` auto-merging both sides, the resolution yields a merge commit plus a relock commit, and a second run correctly skips via `merge-base --is-ancestor`. Workflow YAML parses and the embedded shell passes `bash -n`.

Not included: #262 (`transformers >= 5.3.0`), the fourth open dep-audit PR. It also edits `obsidian_import/backends/docling.py`, docs, and CHANGELOG, and its lock is far behind `main` — folding it in here would have mixed source changes into a dependency-and-CI PR.

https://claude.ai/code/session_01LUxi29LwaLEMADjbUJLBvn