### PR TITLE
feat: add anydoc backend and default to it for document conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+* add anydoc backend (firecrawl-anydoc) and make it the default for PDF, DOCX, PPTX, XLSX, CSV (#297)
+
 ### Security
 
 * pin soupsieve >=2.8.4 for CVE-2026-49477/49476: ReDoS and memory exhaustion (#266)

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ The mirror of [obsidian-export](https://github.com/neuralsignal/obsidian-export)
 pip install obsidian-import
 ```
 
+The default backend is **anydoc** (included as a core dependency), a fast Rust-based document-to-Markdown converter.
+
 With optional backends:
 
 ```bash
 pip install obsidian-import[markitdown]    # fallback for HTML, etc.
-pip install obsidian-import[docling]       # high-quality ML-based extraction
+pip install obsidian-import[docling]       # high-quality ML-based extraction (requires torch)
 ```
 
 ## Quick Start
@@ -130,16 +132,16 @@ output:
     - page_count
 
 backends:
-  pdf: native        # pdfplumber + pypdf
-  docx: native       # defusedxml
-  pptx: native       # python-pptx
-  xlsx: native       # openpyxl
-  csv: native        # stdlib csv -> GFM table
+  pdf: anydoc        # default: fast Rust-based converter (firecrawl-anydoc)
+  docx: anydoc
+  pptx: anydoc
+  xlsx: anydoc
+  csv: anydoc
   json: native       # stdlib json -> fenced code block
   yaml: native       # PyYAML -> fenced code block
   image: native      # Obsidian ![[wikilink]] embed
   html: markitdown   # .html / .htm via markitdown (no native backend)
-  default: native    # fallback for unknown extensions
+  default: anydoc    # fallback for unknown extensions
 
 extraction:
   timeout_seconds: 120
@@ -163,9 +165,10 @@ passthrough:
 
 | Backend | Extensions | Dependencies | Quality |
 |---------|-----------|--------------|---------|
+| `anydoc` | .pdf, .docx, .pptx, .xlsx, .csv, .doc, .rtf, .epub, .odt, .ods, .odp, + more | Core (included) | **Default** — fast Rust-based, highest quality across formats |
 | `native` | .pdf, .docx, .pptx, .xlsx, .csv, .json, .yaml/.yml, images | Core (included) | Good for text-heavy documents |
 | `markitdown` | Any | `[markitdown]` extra | Good fallback for HTML, etc. |
-| `docling` | Any | `[docling]` extra | Best for complex layouts, tables |
+| `docling` | Any | `[docling]` extra | Best for complex layouts, tables (requires torch) |
 
 > **Security note (docling backend):** The `docling` extra depends on `torch`, which has a
 > known deserialization vulnerability ([PYSEC-2026-139](https://github.com/pytorch/pytorch))

--- a/obsidian_import/backends/anydoc.py
+++ b/obsidian_import/backends/anydoc.py
@@ -1,0 +1,33 @@
+"""Document extraction using anydoc.
+
+Requires the firecrawl-anydoc package (core dependency).
+anydoc is a fast Rust-based document-to-Markdown converter by Firecrawl.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from obsidian_import.exceptions import BackendNotAvailableError
+from obsidian_import.timeout import TimeoutContext, run_with_timeout
+
+
+def extract(path: Path, timeout_seconds: int, isolation: str) -> str:
+    """Extract text using anydoc for high-quality document conversion."""
+    try:
+        import anydoc  # noqa: F401
+    except ImportError as exc:
+        raise BackendNotAvailableError("anydoc is not installed. Install with: pip install firecrawl-anydoc") from exc
+
+    ctx = TimeoutContext(timeout_seconds=timeout_seconds, label="anydoc", path=path, isolation=isolation)
+    return run_with_timeout(_extract_anydoc, (path,), ctx)
+
+
+def _extract_anydoc(path: Path) -> str:
+    """Internal anydoc extraction logic (module-level for process isolation)."""
+    import anydoc
+
+    text = anydoc.to_markdown(str(path))
+    if not text or not text.strip():
+        return f"*No text content extracted from `{path.name}`.*"
+    return text

--- a/obsidian_import/cli.py
+++ b/obsidian_import/cli.py
@@ -135,6 +135,7 @@ def doctor() -> None:
         ("native (json)", "native", ".json"),
         ("native (yaml)", "native", ".yaml"),
         ("native (image)", "native", ".png"),
+        ("anydoc", "anydoc", ".pdf"),
         ("markitdown", "markitdown", ".pdf"),
         ("docling", "docling", ".pdf"),
     ]
@@ -144,7 +145,7 @@ def doctor() -> None:
         available, message = check_backend_available(backend, ext)
         status = "OK" if available else "MISSING"
         click.echo(f"  {label:20s}  [{status}]  {message}")
-        if not available and backend == "native":
+        if not available and backend in ("native", "anydoc"):
             all_ok = False
 
     tools = {

--- a/obsidian_import/defaults/default.yaml
+++ b/obsidian_import/defaults/default.yaml
@@ -13,16 +13,16 @@ output:
     - page_count
 
 backends:
-  pdf: native
-  docx: native
-  pptx: native
-  xlsx: native
-  csv: native
+  pdf: anydoc
+  docx: anydoc
+  pptx: anydoc
+  xlsx: anydoc
+  csv: anydoc
   json: native
   yaml: native
   image: native
   html: markitdown
-  default: native
+  default: anydoc
 
 extraction:
   timeout_seconds: 120

--- a/obsidian_import/registry.py
+++ b/obsidian_import/registry.py
@@ -68,6 +68,7 @@ _BACKEND_MODULES: dict[str, str | dict[str, str]] = {
     },
     "markitdown": "obsidian_import.backends.markitdown",
     "docling": "obsidian_import.backends.docling",
+    "anydoc": "obsidian_import.backends.anydoc",
 }
 
 
@@ -86,7 +87,7 @@ def _resolve_module_path(backend_name: str, extension: str) -> str:
                 f"Supported native extensions: {', '.join(native_map.keys())}"
             )
         module_path = native_map[extension]
-    elif backend_name in ("markitdown", "docling"):
+    elif backend_name in ("markitdown", "docling", "anydoc"):
         module_path = _BACKEND_MODULES[backend_name]
         if not isinstance(module_path, str):
             raise UnsupportedFormatError(f"Internal: backend module path misconfigured for '{backend_name}'")

--- a/pixi.lock
+++ b/pixi.lock
@@ -193,6 +193,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/0b/d2943ee6b5eab1a673fe96333070b67232e819cc39728294a7034176006f/firecrawl_anydoc-0.1.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dd/34/b6f19941adcdaf415b5e8a8d577499f5b6a76b59cbae37f9b125a9ffe9f2/polyfactory-3.3.0-py3-none-any.whl
@@ -356,6 +357,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/af/342a3fcaab2d6cc80ecf636cbab9e3b29205467c21cf1ec6dbf9e2a77814/firecrawl_anydoc-0.1.6-cp310-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl
@@ -1020,6 +1022,8 @@ packages:
   - python-pptx>=1.0,<2
   - openpyxl>=3.1,<4
   - pillow>=12.3.0,<13
+  - firecrawl-anydoc>=0.1.6,<0.2
+  - firecrawl-anydoc>=0.1.6,<0.2 ; extra == 'anydoc'
   - markitdown[all]>=0.1,<0.2 ; extra == 'markitdown'
   - docling>=2.0,<3 ; extra == 'docling'
   - pytest>=9.0.3,<10 ; extra == 'dev'
@@ -3653,6 +3657,11 @@ packages:
   - trove-classifiers>=2024.10.12 ; extra == 'tests'
   - defusedxml ; extra == 'xmp'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ca/af/342a3fcaab2d6cc80ecf636cbab9e3b29205467c21cf1ec6dbf9e2a77814/firecrawl_anydoc-0.1.6-cp310-abi3-macosx_11_0_arm64.whl
+  name: firecrawl-anydoc
+  version: 0.1.6
+  sha256: f102e87c004bcf6de979a1697776774454f814d85893e47fedc58fdf838a2f9b
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
   name: iniconfig
   version: 2.3.0
@@ -3811,6 +3820,11 @@ packages:
   - lxml>=3.1.0
   - typing-extensions>=4.9.0
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/db/0b/d2943ee6b5eab1a673fe96333070b67232e819cc39728294a7034176006f/firecrawl_anydoc-0.1.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: firecrawl-anydoc
+  version: 0.1.6
+  sha256: d3e65bbe6709a3a02dc4faf6af8b387016ac4ac2a5b38a70a9f950a8efa492d0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
   name: cfgv
   version: 3.5.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,6 +22,7 @@ python-pptx = ">=1.0,<2"
 openpyxl = ">=3.1,<4"
 idna = ">=3.15,<4"  # CVE-2026-45409: ReDoS incomplete fix
 Pillow = ">=12.3.0,<13"  # PYSEC-2026-2253/2254/2255/2256/2257: memory bomb + shell injection fixes
+firecrawl-anydoc = ">=0.1.6,<0.2"
 pytest = ">=9.0.3,<10"
 hypothesis = ">=6.0,<7"
 ruff = ">=0.11,<1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,11 @@ dependencies = [
     "python-pptx>=1.0,<2",
     "openpyxl>=3.1,<4",
     "Pillow>=12.3.0,<13",
+    "firecrawl-anydoc>=0.1.6,<0.2",
 ]
 
 [project.optional-dependencies]
+anydoc = ["firecrawl-anydoc>=0.1.6,<0.2"]
 markitdown = ["markitdown[all]>=0.1,<0.2"]
 docling = ["docling>=2.0,<3"]
 dev = ["pytest>=9.0.3,<10", "hypothesis>=6.0,<7", "pytest-cov>=5.0,<6"]

--- a/tests/test_anydoc_backend.py
+++ b/tests/test_anydoc_backend.py
@@ -1,0 +1,159 @@
+"""Tests for anydoc backend (mock anydoc)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from obsidian_import.exceptions import BackendNotAvailableError
+
+
+class TestAnydocExtract:
+    def test_extracts_text(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "doc.pdf"
+        test_file.write_bytes(b"fake-pdf-content")
+
+        mock_anydoc = MagicMock()
+        mock_anydoc.to_markdown.return_value = "# Report\n\nExtracted content from PDF."
+
+        with patch.dict("sys.modules", {"anydoc": mock_anydoc}):
+            import importlib
+
+            import obsidian_import.backends.anydoc as mod
+
+            importlib.reload(mod)
+            result = mod.extract(test_file, timeout_seconds=30, isolation="thread")
+
+        assert "Extracted content" in result
+        mock_anydoc.to_markdown.assert_called_once_with(str(test_file))
+
+    def test_empty_result_returns_message(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "empty.docx"
+        test_file.write_bytes(b"fake-docx-content")
+
+        mock_anydoc = MagicMock()
+        mock_anydoc.to_markdown.return_value = ""
+
+        with patch.dict("sys.modules", {"anydoc": mock_anydoc}):
+            import importlib
+
+            import obsidian_import.backends.anydoc as mod
+
+            importlib.reload(mod)
+            result = mod.extract(test_file, timeout_seconds=30, isolation="thread")
+
+        assert "No text content" in result
+        assert "empty.docx" in result
+
+    def test_whitespace_only_returns_message(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "blank.pptx"
+        test_file.write_bytes(b"fake-pptx-content")
+
+        mock_anydoc = MagicMock()
+        mock_anydoc.to_markdown.return_value = "   \n\n  "
+
+        with patch.dict("sys.modules", {"anydoc": mock_anydoc}):
+            import importlib
+
+            import obsidian_import.backends.anydoc as mod
+
+            importlib.reload(mod)
+            result = mod.extract(test_file, timeout_seconds=30, isolation="thread")
+
+        assert "No text content" in result
+
+    def test_missing_dependency_raises(self) -> None:
+        with (
+            patch.dict("sys.modules", {"anydoc": None}),
+            pytest.raises(BackendNotAvailableError, match="anydoc is not installed"),
+        ):
+            import importlib
+
+            import obsidian_import.backends.anydoc as mod
+
+            importlib.reload(mod)
+            mod.extract(Path("/tmp/test.pdf"), timeout_seconds=30, isolation="thread")
+
+    def test_none_result_returns_message(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "null.xlsx"
+        test_file.write_bytes(b"fake-xlsx-content")
+
+        mock_anydoc = MagicMock()
+        mock_anydoc.to_markdown.return_value = None
+
+        with patch.dict("sys.modules", {"anydoc": mock_anydoc}):
+            import importlib
+
+            import obsidian_import.backends.anydoc as mod
+
+            importlib.reload(mod)
+            result = mod.extract(test_file, timeout_seconds=30, isolation="thread")
+
+        assert "No text content" in result
+
+
+class TestAnydocRegistryDispatch:
+    def test_anydoc_dispatch_for_pdf(self) -> None:
+        from obsidian_import.config import BackendsConfig
+        from obsidian_import.registry import get_backend_module
+
+        backends = BackendsConfig(
+            pdf="anydoc",
+            docx="native",
+            pptx="native",
+            xlsx="native",
+            csv="native",
+            json="native",
+            yaml="native",
+            image="native",
+            html="native",
+            default="native",
+        )
+        module = get_backend_module(".pdf", backends)
+        assert module.__name__ == "obsidian_import.backends.anydoc"
+
+    def test_anydoc_as_default_for_unknown_extension(self) -> None:
+        from obsidian_import.config import BackendsConfig
+        from obsidian_import.registry import get_backend_module
+
+        backends = BackendsConfig(
+            pdf="native",
+            docx="native",
+            pptx="native",
+            xlsx="native",
+            csv="native",
+            json="native",
+            yaml="native",
+            image="native",
+            html="native",
+            default="anydoc",
+        )
+        module = get_backend_module(".rtf", backends)
+        assert module.__name__ == "obsidian_import.backends.anydoc"
+
+    def test_anydoc_dispatch_for_all_configured_formats(self) -> None:
+        from obsidian_import.config import BackendsConfig
+        from obsidian_import.registry import get_backend_module
+
+        backends = BackendsConfig(
+            pdf="anydoc",
+            docx="anydoc",
+            pptx="anydoc",
+            xlsx="anydoc",
+            csv="anydoc",
+            json="native",
+            yaml="native",
+            image="native",
+            html="markitdown",
+            default="anydoc",
+        )
+        for ext in (".pdf", ".docx", ".pptx", ".xlsx", ".csv"):
+            module = get_backend_module(ext, backends)
+            assert module.__name__ == "obsidian_import.backends.anydoc", f"Failed for {ext}"
+
+    def test_anydoc_backend_check_available(self) -> None:
+        from obsidian_import.registry import check_backend_available
+
+        available, message = check_backend_available("anydoc", ".pdf")
+        assert isinstance(available, bool)
+        assert isinstance(message, str)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,16 +64,17 @@ class TestDefaultConfig:
         config = default_config()
         assert isinstance(config, ImportConfig)
 
-    def test_default_backends_are_native(self):
+    def test_default_backends(self):
         config = default_config()
-        assert config.backends.pdf == "native"
-        assert config.backends.docx == "native"
-        assert config.backends.pptx == "native"
-        assert config.backends.xlsx == "native"
-        assert config.backends.csv == "native"
+        assert config.backends.pdf == "anydoc"
+        assert config.backends.docx == "anydoc"
+        assert config.backends.pptx == "anydoc"
+        assert config.backends.xlsx == "anydoc"
+        assert config.backends.csv == "anydoc"
         assert config.backends.json == "native"
         assert config.backends.yaml == "native"
         assert config.backends.image == "native"
+        assert config.backends.default == "anydoc"
 
     def test_default_html_backend_is_markitdown(self):
         # Native has no .html handler; defaulting html to markitdown keeps
@@ -445,11 +446,11 @@ backends:
         assert config.backends.image == "markitdown"
         assert config.backends.html == "native"
 
-    def test_new_backend_keys_default_to_native(self, tmp_path):
+    def test_new_backend_keys_have_correct_defaults(self, tmp_path):
         config_file = tmp_path / "config.yaml"
         config_file.write_text("")
         config = load_config(config_file)
-        assert config.backends.csv == "native"
+        assert config.backends.csv == "anydoc"
         assert config.backends.json == "native"
         assert config.backends.yaml == "native"
         assert config.backends.image == "native"

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -37,7 +37,7 @@ class TestConfigFromOverrides:
     def test_backend_override(self) -> None:
         config = config_from_overrides({"backends": {"pdf": "markitdown"}})
         assert config.backends.pdf == "markitdown"
-        assert config.backends.docx == "native"
+        assert config.backends.docx == "anydoc"
 
     def test_invalid_overrides_raise_config_error(self) -> None:
         with pytest.raises(ConfigError):


### PR DESCRIPTION
## Summary

- Add firecrawl-anydoc as a core dependency and implement the anydoc backend
- Change defaults for PDF, DOCX, PPTX, XLSX, CSV from native to anydoc
- Native backends remain available via config override

Closes #297

Generated with [Claude Code](https://claude.ai/code)