### PR TITLE
feat: default document conversion to anydoc, with inline image embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Features
+
+* add an `anydoc` backend and make it the default for document conversion (#297)
+  * PDF, DOCX, PPTX, XLSX, and CSV now convert through
+    [anydoc](https://github.com/firecrawl/anydoc), a required dependency, and
+    `backends.default` is `anydoc`, so `.doc`, `.xls`, `.ppt`, `.odt`, `.ods`,
+    `.odp`, `.rtf`, and `.epub` convert without extra configuration.
+  * JSON, YAML, and image files keep the native backends; HTML keeps markitdown.
+  * Two behavior changes for anydoc-backed formats: PDFs are extracted text
+    only (set `backends.pdf: native` to keep PDF image extraction, which also
+    keeps scanned PDFs from erroring), and `extraction.xlsx_max_rows_per_sheet`
+    no longer applies to `.xlsx` (set `backends.xlsx: native` to cap rows).
+  * Images embedded in Word, PowerPoint, Excel, OpenDocument, and EPUB files
+    are extracted and embedded at the end of the note; anydoc's markdown holds
+    no reference to an embedded image, so the wikilinks are not placed inline.
+
+### Bug Fixes
+
+* report a backend's ignored config options once per configuration instead of
+  once per file, so batch runs no longer repeat the same warning for every
+  document (#297)
+
 ### Security
 
 * pin soupsieve >=2.8.4 for CVE-2026-49477/49476: ReDoS and memory exhaustion (#266)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,23 @@
 ### Features
 
 * add an `anydoc` backend and make it the default for document conversion (#297)
-  * PDF, DOCX, PPTX, XLSX, and CSV now convert through
+  * DOCX, PPTX, XLSX, and CSV now convert through
     [anydoc](https://github.com/firecrawl/anydoc), a required dependency, and
     `backends.default` is `anydoc`, so `.doc`, `.xls`, `.ppt`, `.odt`, `.ods`,
     `.odp`, `.rtf`, and `.epub` convert without extra configuration.
+  * PDF stays on the native backend: anydoc exposes no document model for PDF,
+    so it cannot extract page images, `## Page N` headings, or the `page_count`
+    frontmatter derived from them, and it has no OCR for scanned PDFs. Set
+    `backends.pdf: anydoc` to use anydoc for PDFs anyway.
   * JSON, YAML, and image files keep the native backends; HTML keeps markitdown.
-  * Two behavior changes for anydoc-backed formats: PDFs are extracted text
-    only (set `backends.pdf: native` to keep PDF image extraction, which also
-    keeps scanned PDFs from erroring), and `extraction.xlsx_max_rows_per_sheet`
-    no longer applies to `.xlsx` (set `backends.xlsx: native` to cap rows).
-  * Images embedded in Word, PowerPoint, Excel, OpenDocument, and EPUB files
-    are extracted and embedded at the end of the note; anydoc's markdown holds
-    no reference to an embedded image, so the wikilinks are not placed inline.
+  * Images embedded in Word, PowerPoint, Excel, OpenDocument, and EPUB files are
+    extracted into the note's media folder and embedded as wikilinks at the
+    position they held in the source document. anydoc's markdown contains no
+    reference to an embedded image, so the embeds are spliced in by aligning its
+    markdown blocks with the document model that carries the images; if the two
+    stop lining up, the remaining images are embedded at the end of the note.
+  * `extraction.xlsx_max_rows_per_sheet` does not apply to anydoc; set
+    `backends.xlsx: native` to cap the rows read per sheet.
 
 ### Bug Fixes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ Python package for extracting files (PDF, DOCX, PPTX, XLSX) into Obsidian-flavor
 | Path | Purpose |
 |------|---------|
 | `obsidian_import/` | Source package |
-| `obsidian_import/backends/` | Extraction backends (native, markitdown, docling) |
+| `obsidian_import/backends/` | Extraction backends (anydoc, native, markitdown, docling) |
+| `obsidian_import/anydoc_placement.py` | Inline placement of anydoc media embeds |
 | `obsidian_import/config.py` | Config dataclasses + YAML loading |
 | `obsidian_import/cli.py` | CLI entry point |
 | `obsidian_import/registry.py` | Extension → backend dispatch |

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ output:
     - page_count
 
 backends:
-  pdf: anydoc        # anydoc (text only for PDF; use native for PDF images)
+  pdf: native        # pdfplumber + pypdf: page headings, page_count, page images
   docx: anydoc       # anydoc
   pptx: anydoc       # anydoc
   xlsx: anydoc       # anydoc (xlsx_max_rows_per_sheet does not apply)
@@ -167,26 +167,29 @@ passthrough:
 
 | Backend | Extensions | Dependencies | Quality |
 |---------|-----------|--------------|---------|
-| `anydoc` (default) | .pdf, .doc/.docx, .ppt/.pptx, .xls/.xlsx, .odt/.ods/.odp, .rtf, .epub, .csv | Core (included) | Best all-round document conversion |
-| `native` | .pdf, .docx, .pptx, .xlsx, .csv, .json, .yaml/.yml, images | Core (included) | Good for text-heavy documents; the only backend that pulls images out of PDFs |
+| `anydoc` (default) | .doc/.docx, .ppt/.pptx, .xls/.xlsx, .odt/.ods/.odp, .rtf, .epub, .csv, .pdf (opt-in) | Core (included) | Best all-round document conversion |
+| `native` | .pdf (default), .docx, .pptx, .xlsx, .csv, .json, .yaml/.yml, images | Core (included) | Good for text-heavy documents; the only backend that pulls images out of PDFs |
 | `markitdown` | Any | `[markitdown]` extra | Good fallback for HTML, etc. |
 | `docling` | Any | `[docling]` extra | Best for complex layouts, tables |
 
 The `anydoc` backend wraps [anydoc](https://github.com/firecrawl/anydoc), a Rust
 document converter that ships as a compiled wheel — no model downloads, no
-extra install step. Two differences from the native backends are worth knowing
-before you keep the defaults:
+extra install step. Embedded images from Word, PowerPoint, Excel, OpenDocument,
+and EPUB input are extracted into the note's media folder and embedded as
+`![[note/asset_imgN.png]]` at the position they occupied in the source
+document.
 
-- **PDFs come out text only.** anydoc converts PDF straight to Markdown and
-  exposes no image model for it. Set `pdf: native` to keep per-page image
-  extraction. Image-only (scanned) PDFs fail with an extraction error rather
-  than an empty note, because anydoc does no OCR.
-- **`extraction.xlsx_max_rows_per_sheet` does not apply to anydoc.** The option
-  is logged as ignored for `.xlsx` files; set `xlsx: native` to cap rows.
+**PDF is the one document format anydoc is not the default for.** anydoc parses
+PDF straight to Markdown and exposes no document model for it, which costs three
+things the native PDF backend gives you: embedded page images, the `## Page N`
+headings, and the `page_count` frontmatter field derived from them. anydoc also
+does no OCR, so a scanned PDF fails with an extraction error instead of
+producing an empty note. Set `pdf: anydoc` if you would rather have anydoc's
+PDF text extraction than any of that.
 
-Embedded images from Word, PowerPoint, Excel, OpenDocument, and EPUB inputs are
-extracted and embedded at the end of the note: anydoc's Markdown carries no
-reference to an embedded image, so the wikilinks cannot be placed inline.
+One further difference: `extraction.xlsx_max_rows_per_sheet` does not apply to
+anydoc. The option is reported as ignored for `.xlsx`; set `xlsx: native` to cap
+rows per sheet.
 
 > **Security note (docling backend):** The `docling` extra depends on `torch`, which has a
 > known deserialization vulnerability ([PYSEC-2026-139](https://github.com/pytorch/pytorch))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # obsidian-import
 
-Extract files (PDF, DOCX, PPTX, XLSX, CSV, JSON, YAML, images) into Obsidian-flavored Markdown.
+Extract files (PDF, Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, JSON, YAML, images) into Obsidian-flavored Markdown.
 
 The mirror of [obsidian-export](https://github.com/neuralsignal/obsidian-export): where obsidian-export converts Obsidian notes to PDF/DOCX, obsidian-import converts external documents into Obsidian-ready markdown with YAML frontmatter.
 
@@ -9,6 +9,10 @@ The mirror of [obsidian-export](https://github.com/neuralsignal/obsidian-export)
 ```bash
 pip install obsidian-import
 ```
+
+Document conversion runs on [anydoc](https://github.com/firecrawl/anydoc) by
+default; it is a required dependency, so no extra is needed for PDF, Word,
+PowerPoint, Excel, OpenDocument, RTF, EPUB, or CSV input.
 
 With optional backends:
 
@@ -130,16 +134,16 @@ output:
     - page_count
 
 backends:
-  pdf: native        # pdfplumber + pypdf
-  docx: native       # defusedxml
-  pptx: native       # python-pptx
-  xlsx: native       # openpyxl
-  csv: native        # stdlib csv -> GFM table
-  json: native       # stdlib json -> fenced code block
-  yaml: native       # PyYAML -> fenced code block
-  image: native      # Obsidian ![[wikilink]] embed
-  html: markitdown   # .html / .htm via markitdown (no native backend)
-  default: native    # fallback for unknown extensions
+  pdf: anydoc        # anydoc (text only for PDF; use native for PDF images)
+  docx: anydoc       # anydoc
+  pptx: anydoc       # anydoc
+  xlsx: anydoc       # anydoc (xlsx_max_rows_per_sheet does not apply)
+  csv: anydoc        # anydoc -> GFM table
+  json: native       # stdlib json -> fenced code block (no anydoc parser)
+  yaml: native       # PyYAML -> fenced code block (no anydoc parser)
+  image: native      # Obsidian ![[wikilink]] embed (no anydoc parser)
+  html: markitdown   # .html / .htm via markitdown (no anydoc parser)
+  default: anydoc    # fallback for unlisted extensions (.doc, .rtf, .odt, ...)
 
 extraction:
   timeout_seconds: 120
@@ -163,9 +167,26 @@ passthrough:
 
 | Backend | Extensions | Dependencies | Quality |
 |---------|-----------|--------------|---------|
-| `native` | .pdf, .docx, .pptx, .xlsx, .csv, .json, .yaml/.yml, images | Core (included) | Good for text-heavy documents |
+| `anydoc` (default) | .pdf, .doc/.docx, .ppt/.pptx, .xls/.xlsx, .odt/.ods/.odp, .rtf, .epub, .csv | Core (included) | Best all-round document conversion |
+| `native` | .pdf, .docx, .pptx, .xlsx, .csv, .json, .yaml/.yml, images | Core (included) | Good for text-heavy documents; the only backend that pulls images out of PDFs |
 | `markitdown` | Any | `[markitdown]` extra | Good fallback for HTML, etc. |
 | `docling` | Any | `[docling]` extra | Best for complex layouts, tables |
+
+The `anydoc` backend wraps [anydoc](https://github.com/firecrawl/anydoc), a Rust
+document converter that ships as a compiled wheel — no model downloads, no
+extra install step. Two differences from the native backends are worth knowing
+before you keep the defaults:
+
+- **PDFs come out text only.** anydoc converts PDF straight to Markdown and
+  exposes no image model for it. Set `pdf: native` to keep per-page image
+  extraction. Image-only (scanned) PDFs fail with an extraction error rather
+  than an empty note, because anydoc does no OCR.
+- **`extraction.xlsx_max_rows_per_sheet` does not apply to anydoc.** The option
+  is logged as ignored for `.xlsx` files; set `xlsx: native` to cap rows.
+
+Embedded images from Word, PowerPoint, Excel, OpenDocument, and EPUB inputs are
+extracted and embedded at the end of the note: anydoc's Markdown carries no
+reference to an embedded image, so the wikilinks cannot be placed inline.
 
 > **Security note (docling backend):** The `docling` extra depends on `torch`, which has a
 > known deserialization vulnerability ([PYSEC-2026-139](https://github.com/pytorch/pytorch))
@@ -174,6 +195,8 @@ passthrough:
 > trusted sources.
 
 ### Format-Specific Behavior
+
+Native backend output, for the formats it covers:
 
 | Format | Native Backend Output |
 |--------|----------------------|

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,6 +6,11 @@
 pip install obsidian-import
 ```
 
+This installs the default document backend,
+[anydoc](https://github.com/firecrawl/anydoc), which handles PDF, Word,
+PowerPoint, Excel, OpenDocument, RTF, EPUB, and CSV input. It ships as a
+compiled wheel, so there is nothing further to install for those formats.
+
 ### Optional backends
 
 Install extras for additional backend support:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,9 +7,10 @@ pip install obsidian-import
 ```
 
 This installs the default document backend,
-[anydoc](https://github.com/firecrawl/anydoc), which handles PDF, Word,
-PowerPoint, Excel, OpenDocument, RTF, EPUB, and CSV input. It ships as a
-compiled wheel, so there is nothing further to install for those formats.
+[anydoc](https://github.com/firecrawl/anydoc), which handles Word, PowerPoint,
+Excel, OpenDocument, RTF, EPUB, and CSV input (PDFs stay on the native backend
+by default). It ships as a compiled wheel, so there is nothing further to
+install for those formats.
 
 ### Optional backends
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The mirror of [obsidian-export](https://github.com/neuralsignal/obsidian-export)
 
 ## Features
 
-- **anydoc by default** for document conversion: PDF, Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, and CSV, with no extra install
+- **anydoc by default** for document conversion: Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, and CSV, with no extra install (PDFs stay on the native backend, which extracts page images and page headings)
 - **Native backends** for PDF (pdfplumber + pypdf), DOCX (defusedxml), PPTX (python-pptx), XLSX (openpyxl), CSV, JSON, YAML, and image files
 - **Optional backends**: markitdown (fallback for HTML and other formats) and docling (high-quality ML-based extraction)
 - **Embedded media extraction**: images embedded in documents are extracted and linked as Obsidian wikilinks

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,15 @@
 # obsidian-import
 
-Extract files (PDF, DOCX, PPTX, XLSX) into Obsidian-flavored Markdown.
+Extract files (PDF, Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, JSON, YAML, images) into Obsidian-flavored Markdown.
 
 The mirror of [obsidian-export](https://github.com/neuralsignal/obsidian-export): where obsidian-export converts Obsidian notes to PDF/DOCX, obsidian-import converts external documents into Obsidian-ready markdown with YAML frontmatter.
 
 ## Features
 
+- **anydoc by default** for document conversion: PDF, Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, and CSV, with no extra install
 - **Native backends** for PDF (pdfplumber + pypdf), DOCX (defusedxml), PPTX (python-pptx), XLSX (openpyxl), CSV, JSON, YAML, and image files
 - **Optional backends**: markitdown (fallback for HTML and other formats) and docling (high-quality ML-based extraction)
-- **Embedded media extraction**: images embedded in PDF, DOCX, and PPTX are extracted and linked as Obsidian wikilinks
+- **Embedded media extraction**: images embedded in documents are extracted and linked as Obsidian wikilinks
 - **Pass-through mode**: copy files as-is without extraction (configurable by extension, glob, or regex)
 - **Config-driven** backend selection per file type
 - **Glob-based file discovery** with exclude patterns

--- a/docs/user-guide/backends.md
+++ b/docs/user-guide/backends.md
@@ -6,9 +6,34 @@ obsidian-import uses a backend system to handle different file formats. Each bac
 
 | Backend | Extensions | Dependencies | Quality |
 |---------|-----------|--------------|---------|
-| `native` | .pdf, .docx, .pptx, .xlsx, .csv, .json, .yaml, images | Core (included) | Good for text-heavy documents |
+| `anydoc` (default) | .pdf, .doc/.docx, .ppt/.pptx, .xls/.xlsx, .odt/.ods/.odp, .rtf, .epub, .csv | Core (included) | Best all-round document conversion |
+| `native` | .pdf, .docx, .pptx, .xlsx, .csv, .json, .yaml, images | Core (included) | Good for text-heavy documents; the only backend that pulls images out of PDFs |
 | `markitdown` | Any | `pip install obsidian-import[markitdown]` | Good fallback for HTML and other formats |
 | `docling` | Any | `pip install obsidian-import[docling]` | Best for complex layouts and tables |
+
+## anydoc (default)
+
+[anydoc](https://github.com/firecrawl/anydoc) is a Rust document converter that
+ships as a compiled wheel — no model downloads and no extra install step — and
+it is the default for every document format. It also covers formats no native
+backend reads: legacy Office files (`.doc`, `.xls`, `.ppt`), OpenDocument
+(`.odt`, `.ods`, `.odp`), `.rtf`, and `.epub`. Those extensions have no
+`backends` key of their own, so they are dispatched by `backends.default`.
+
+Two behaviors differ from the native backends:
+
+- **PDF extraction is text only.** anydoc converts PDF straight to Markdown and
+  exposes no image model for it, so `media.extract_images` has no effect on
+  PDFs. Set `pdf: native` to keep per-page image extraction. anydoc does no
+  OCR, so an image-only (scanned) PDF raises an extraction error instead of
+  producing an empty note.
+- **`extraction.xlsx_max_rows_per_sheet` does not apply.** The option is logged
+  as ignored for `.xlsx` files; set `xlsx: native` to cap rows per sheet.
+
+Embedded images in Word, PowerPoint, Excel, OpenDocument, and EPUB files are
+extracted into the note's media folder and embedded at the end of the note.
+anydoc's Markdown holds no reference to an embedded image, so the wikilinks
+cannot be placed at the position the image occupied in the source.
 
 ## Native Backends
 
@@ -72,11 +97,11 @@ Configure which backend to use per file type in `config.yaml`:
 
 ```yaml
 backends:
-  pdf: native
-  docx: native
-  pptx: native
-  xlsx: native
-  default: native
+  pdf: native      # keep pdfplumber page headings and PDF image extraction
+  docx: anydoc
+  pptx: anydoc
+  xlsx: anydoc
+  default: anydoc
 ```
 
 The `default` key specifies the fallback backend for file extensions not explicitly listed.

--- a/docs/user-guide/backends.md
+++ b/docs/user-guide/backends.md
@@ -6,7 +6,7 @@ obsidian-import uses a backend system to handle different file formats. Each bac
 
 | Backend | Extensions | Dependencies | Quality |
 |---------|-----------|--------------|---------|
-| `anydoc` (default) | .pdf, .doc/.docx, .ppt/.pptx, .xls/.xlsx, .odt/.ods/.odp, .rtf, .epub, .csv | Core (included) | Best all-round document conversion |
+| `anydoc` (default) | .doc/.docx, .ppt/.pptx, .xls/.xlsx, .odt/.ods/.odp, .rtf, .epub, .csv, .pdf (opt-in) | Core (included) | Best all-round document conversion |
 | `native` | .pdf, .docx, .pptx, .xlsx, .csv, .json, .yaml, images | Core (included) | Good for text-heavy documents; the only backend that pulls images out of PDFs |
 | `markitdown` | Any | `pip install obsidian-import[markitdown]` | Good fallback for HTML and other formats |
 | `docling` | Any | `pip install obsidian-import[docling]` | Best for complex layouts and tables |
@@ -15,25 +15,46 @@ obsidian-import uses a backend system to handle different file formats. Each bac
 
 [anydoc](https://github.com/firecrawl/anydoc) is a Rust document converter that
 ships as a compiled wheel — no model downloads and no extra install step — and
-it is the default for every document format. It also covers formats no native
-backend reads: legacy Office files (`.doc`, `.xls`, `.ppt`), OpenDocument
-(`.odt`, `.ods`, `.odp`), `.rtf`, and `.epub`. Those extensions have no
-`backends` key of their own, so they are dispatched by `backends.default`.
+it is the default for every document format except PDF (see below). It also
+covers formats no native backend reads: legacy Office files (`.doc`, `.xls`,
+`.ppt`), OpenDocument (`.odt`, `.ods`, `.odp`), `.rtf`, and `.epub`. Those
+extensions have no `backends` key of their own, so they are dispatched by
+`backends.default`.
 
-Two behaviors differ from the native backends:
+### Embedded images
 
-- **PDF extraction is text only.** anydoc converts PDF straight to Markdown and
-  exposes no image model for it, so `media.extract_images` has no effect on
-  PDFs. Set `pdf: native` to keep per-page image extraction. anydoc does no
-  OCR, so an image-only (scanned) PDF raises an extraction error instead of
-  producing an empty note.
-- **`extraction.xlsx_max_rows_per_sheet` does not apply.** The option is logged
-  as ignored for `.xlsx` files; set `xlsx: native` to cap rows per sheet.
+Images in Word, PowerPoint, Excel, OpenDocument, and EPUB files are extracted
+into the note's media folder and embedded as `![[note/asset_imgN.png]]` at the
+position they occupied in the source document, including images inside table
+cells, list items, and block quotes (those are embedded directly after the
+table, list, or quote that holds them).
 
-Embedded images in Word, PowerPoint, Excel, OpenDocument, and EPUB files are
-extracted into the note's media folder and embedded at the end of the note.
-anydoc's Markdown holds no reference to an embedded image, so the wikilinks
-cannot be placed at the position the image occupied in the source.
+anydoc renders an embedded image as its alt text — or as nothing when it has
+none — and has no option to emit an image reference, so there is nothing in its
+Markdown to rewrite into a wikilink. The embeds are instead spliced in by
+matching anydoc's Markdown blocks against the document model that carries the
+images, block by block. If the two ever stop lining up, placement stops there
+and the remaining images are embedded at the end of the note rather than at a
+guessed position.
+
+### PDF is not on anydoc by default
+
+anydoc parses PDF straight to Markdown and exposes no document model for it,
+which costs three things the native PDF backend provides:
+
+- embedded page images (`media.extract_images` has no effect on anydoc PDFs)
+- the `## Page N` headings
+- the `page_count` frontmatter field, which is derived from those headings
+
+anydoc also does no OCR, so an image-only (scanned) PDF raises an extraction
+error instead of producing an empty note. The bundled default is therefore
+`pdf: native`; set `pdf: anydoc` to convert PDFs with anydoc anyway.
+
+### xlsx row cap
+
+`extraction.xlsx_max_rows_per_sheet` does not apply to anydoc — it is reported
+as an ignored option for `.xlsx` files. Set `xlsx: native` to cap rows per
+sheet.
 
 ## Native Backends
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -23,7 +23,7 @@ output:
     - page_count
 
 backends:
-  pdf: anydoc        # anydoc (text only for PDF)
+  pdf: native        # pdfplumber + pypdf (page headings, page_count, page images)
   docx: anydoc       # anydoc
   pptx: anydoc       # anydoc
   xlsx: anydoc       # anydoc (xlsx_max_rows_per_sheet does not apply)
@@ -91,9 +91,10 @@ Maps file extensions to extraction backends. See [Backends](backends.md) for det
 
 Valid values: `anydoc`, `native`, `markitdown`, `docling`.
 
-The bundled defaults use `anydoc` for `pdf`, `docx`, `pptx`, `xlsx`, `csv`, and
-`default`; `native` for `json`, `yaml`, and `image`; and `markitdown` for
-`html`. See [Backends](backends.md) for the trade-offs of the anydoc default.
+The bundled defaults use `anydoc` for `docx`, `pptx`, `xlsx`, `csv`, and
+`default`; `native` for `pdf`, `json`, `yaml`, and `image`; and `markitdown` for
+`html`. PDF stays on the native backend because anydoc cannot extract PDF images
+or page headings — see [Backends](backends.md).
 
 ### `extraction`
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -23,15 +23,16 @@ output:
     - page_count
 
 backends:
-  pdf: native        # pdfplumber + pypdf
-  docx: native       # defusedxml
-  pptx: native       # python-pptx
-  xlsx: native       # openpyxl
-  csv: native        # built-in csv module
+  pdf: anydoc        # anydoc (text only for PDF)
+  docx: anydoc       # anydoc
+  pptx: anydoc       # anydoc
+  xlsx: anydoc       # anydoc (xlsx_max_rows_per_sheet does not apply)
+  csv: anydoc        # anydoc
   json: native       # built-in json module
   yaml: native       # pyyaml
   image: native      # Pillow
-  default: native    # fallback for unlisted extensions
+  html: markitdown   # markitdown
+  default: anydoc    # fallback for unlisted extensions
 
 extraction:
   timeout_seconds: 120
@@ -88,7 +89,11 @@ Maps file extensions to extraction backends. See [Backends](backends.md) for det
 | `image` | string | Backend for image files (`.png`, `.jpg`, `.gif`, etc.) |
 | `default` | string | Fallback backend for unlisted extensions |
 
-Valid values: `native`, `markitdown`, `docling`.
+Valid values: `anydoc`, `native`, `markitdown`, `docling`.
+
+The bundled defaults use `anydoc` for `pdf`, `docx`, `pptx`, `xlsx`, `csv`, and
+`default`; `native` for `json`, `yaml`, and `image`; and `markitdown` for
+`html`. See [Backends](backends.md) for the trade-offs of the anydoc default.
 
 ### `extraction`
 

--- a/obsidian_import/anydoc_placement.py
+++ b/obsidian_import/anydoc_placement.py
@@ -1,0 +1,264 @@
+"""Inline placement of media embeds inside anydoc's markdown output.
+
+anydoc renders an embedded image as its alt text, or as nothing when it has
+none, and offers no option to emit an image reference. The rendered markdown
+therefore contains no anchor to rewrite into an Obsidian wikilink, and the
+document model that does carry the images records no character position for
+them. What both sides do share is block order: anydoc's markdown is a sequence
+of blank-line separated blocks in the same order as ``Document.blocks``.
+
+Placement walks the two sequences in step. A block that renders to text
+consumes the next markdown block and its images are embedded after it; a block
+that renders to nothing (an image-only paragraph) consumes no markdown and its
+images are embedded at that position. Each consumed pair is verified against
+the block's own text, and placement stops at the first mismatch rather than
+guessing — anything left unplaced is embedded at the end of the note by
+``extract_file``.
+
+Embeds are inserted at character offsets in the original markdown, so text
+anydoc produced is never rewritten, only interleaved.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterator, Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from anydoc import Block, Document, Inline
+
+from obsidian_import.extraction_result import MediaFile
+from obsidian_import.formatting import make_media_wikilink
+
+log = logging.getLogger(__name__)
+
+_FENCE = "```"
+_ALPHANUMERIC = re.compile(r"[^0-9a-z]+")
+# How much of a block's own text must prefix the markdown block it is matched
+# against. Long enough that neighbouring blocks cannot be confused, short
+# enough to survive the markdown syntax anydoc adds around the text.
+_MATCH_PREFIX_CHARS = 12
+# Block kinds that always produce markdown, whatever text they carry: a rule
+# renders as `---` with no text of its own, and the container kinds always
+# render their children.
+_ALWAYS_RENDERED_KINDS = frozenset({"rule", "table", "list", "block_quote", "code_block"})
+
+
+def place_media_embeds(
+    markdown: str,
+    document: Document,
+    media_by_asset_id: dict[int, MediaFile],
+    doc_stem: str,
+) -> str:
+    """Return the markdown with wikilink embeds inserted at their images' positions.
+
+    Images whose position cannot be established are left out; the caller is
+    responsible for surfacing them (``extract_file`` appends the leftovers).
+    """
+    spans = _block_spans(markdown)
+    insertions = _plan_insertions(document, spans, markdown)
+
+    additions: list[tuple[int, str]] = []
+    for offset, at_block_start, asset_ids in insertions:
+        embeds = [
+            make_media_wikilink(doc_stem, media_by_asset_id[asset_id].filename)
+            for asset_id in asset_ids
+            if asset_id in media_by_asset_id
+        ]
+        if embeds:
+            paragraph = "\n".join(embeds)
+            additions.append((offset, f"{paragraph}\n\n" if at_block_start else f"\n\n{paragraph}"))
+
+    return _apply_insertions(markdown, additions)
+
+
+def _block_spans(markdown: str) -> list[tuple[int, int]]:
+    """Return (start, end) character spans of the blank-line separated markdown blocks.
+
+    Fenced code blocks are kept whole: the blank lines inside them do not
+    separate blocks.
+    """
+    spans: list[tuple[int, int]] = []
+    offset = 0
+    start: int | None = None
+    end = 0
+    in_fence = False
+
+    for line in markdown.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith(_FENCE):
+            in_fence = not in_fence
+        if not stripped and not in_fence:
+            if start is not None:
+                spans.append((start, end))
+                start = None
+        else:
+            if start is None:
+                start = offset
+            end = offset + len(line.rstrip("\n"))
+        offset += len(line)
+
+    if start is not None:
+        spans.append((start, end))
+    return spans
+
+
+def _plan_insertions(
+    document: Document,
+    spans: Sequence[tuple[int, int]],
+    markdown: str,
+) -> list[tuple[int, bool, list[int]]]:
+    """Align document blocks with markdown blocks, planning where images belong.
+
+    Returns (offset, at_block_start, asset_ids) entries. Alignment stops at the
+    first block that does not match the markdown block it consumes.
+    """
+    insertions: list[tuple[int, bool, list[int]]] = []
+    cursor = 0
+
+    for block in document.blocks:
+        asset_ids = list(_image_asset_ids(block))
+        if not _expects_markdown(block):
+            if asset_ids:
+                insertions.append(_insertion_for_unrendered_block(cursor, spans, markdown, asset_ids))
+            continue
+
+        if cursor >= len(spans) or not _matches(block, markdown[spans[cursor][0] : spans[cursor][1]]):
+            if _remaining_asset_ids(document.blocks, block):
+                log.info(
+                    "anydoc markdown no longer lines up with its document model at block %d; "
+                    "the remaining images are embedded at the end of the note instead",
+                    cursor,
+                )
+            break
+
+        if asset_ids:
+            insertions.append((spans[cursor][1], False, asset_ids))
+        cursor += 1
+
+    return insertions
+
+
+def _insertion_for_unrendered_block(
+    cursor: int,
+    spans: Sequence[tuple[int, int]],
+    markdown: str,
+    asset_ids: list[int],
+) -> tuple[int, bool, list[int]]:
+    """Insertion for a block anydoc renders nothing for, so consumes no markdown.
+
+    Its images belong before the markdown block that follows it, or after the
+    last one when the block trails the document.
+    """
+    if cursor < len(spans):
+        return (spans[cursor][0], True, asset_ids)
+    if spans:
+        return (spans[-1][1], False, asset_ids)
+    return (len(markdown), False, asset_ids)
+
+
+def _remaining_asset_ids(blocks: Sequence[Block], from_block: Block) -> list[int]:
+    """Asset ids in from_block and every block after it, for reporting a stopped alignment."""
+    reached = False
+    remaining: list[int] = []
+    for block in blocks:
+        reached = reached or block is from_block
+        if reached:
+            remaining.extend(_image_asset_ids(block))
+    return remaining
+
+
+def _expects_markdown(block: Block) -> bool:
+    """True when the block renders to a markdown block of its own."""
+    if block.kind in _ALWAYS_RENDERED_KINDS:
+        return True
+    return bool(_block_text(block).strip())
+
+
+def _matches(block: Block, rendered: str) -> bool:
+    """True when the rendered markdown block is the rendering of this block.
+
+    Compared on alphanumeric characters only: anydoc wraps and escapes the text
+    it renders (`## `, `- `, `|`, backslashes), none of which survive the
+    reduction, while the text itself does.
+    """
+    expected = _reduce(_block_text(block))
+    if not expected:
+        return True
+    return _reduce(rendered).startswith(expected[:_MATCH_PREFIX_CHARS])
+
+
+def _reduce(text: str) -> str:
+    """Reduce text to its lowercase alphanumeric characters."""
+    return _ALPHANUMERIC.sub("", text.casefold())
+
+
+def _block_text(block: Block) -> str:
+    """The plain text a block renders, including the text of nested blocks."""
+    parts: list[str] = []
+    if block.kind == "code_block":
+        parts.append(f"{block.lang or ''} {block.text or ''}")
+    if block.content is not None:
+        parts.extend(_inline_text(inline) for inline in block.content)
+    for nested in _nested_blocks(block):
+        parts.append(_block_text(nested))
+    return " ".join(part for part in parts if part)
+
+
+def _inline_text(inline: Inline) -> str:
+    """The plain text an inline renders (an image renders its alt text)."""
+    if inline.kind == "image":
+        return inline.alt or ""
+    if inline.content is not None:
+        return " ".join(_inline_text(child) for child in inline.content)
+    return inline.text or ""
+
+
+def _image_asset_ids(block: Block) -> Iterator[int]:
+    """Asset ids of the embedded images in a block, in document order."""
+    if block.content is not None:
+        yield from _inline_asset_ids(block.content)
+    for nested in _nested_blocks(block):
+        yield from _image_asset_ids(nested)
+
+
+def _inline_asset_ids(inlines: Sequence[Inline]) -> Iterator[int]:
+    """Asset ids of the embedded images among inlines, in order."""
+    for inline in inlines:
+        if inline.kind == "image":
+            source = inline.source
+            if source is not None and source.kind == "asset" and source.asset_id is not None:
+                yield source.asset_id
+        elif inline.content is not None:
+            yield from _inline_asset_ids(inline.content)
+
+
+def _nested_blocks(block: Block) -> Iterator[Block]:
+    """The blocks a container block holds: list items, table cells, quoted blocks."""
+    if block.blocks is not None:
+        yield from block.blocks
+    if block.list is not None:
+        for item in block.list.items:
+            yield from item.blocks
+    if block.table is not None:
+        for row in block.table.grid:
+            for slot in row:
+                if slot.kind == "origin" and slot.cell is not None:
+                    yield from slot.cell.blocks
+
+
+def _apply_insertions(markdown: str, additions: Sequence[tuple[int, str]]) -> str:
+    """Insert text at the given character offsets, leaving the rest untouched."""
+    if not additions:
+        return markdown
+
+    pieces: list[str] = []
+    previous = 0
+    for offset, text in sorted(additions, key=lambda addition: addition[0]):
+        pieces.append(markdown[previous:offset])
+        pieces.append(text)
+        previous = offset
+    pieces.append(markdown[previous:])
+    return "".join(pieces)

--- a/obsidian_import/backends/anydoc.py
+++ b/obsidian_import/backends/anydoc.py
@@ -8,13 +8,13 @@ downloads, so it is a required dependency rather than an extra.
 Two behaviors of the upstream library shape this backend:
 
 - Embedded images are absent from anydoc's Markdown: an embedded image renders
-  as its alt text, or as nothing when it has none, and the document model
-  carries no position for an asset. There is therefore no in-text reference to
-  rewrite into a wikilink; extracted images are returned as media files and
-  ``extract_file`` embeds the unreferenced ones at the end of the note.
+  as its alt text, or as nothing when it has none. The images live on the
+  document model instead, which this backend reads to recover them, and
+  ``anydoc_placement`` splices their wikilinks back in at the position they
+  occupied in the source document.
 - PDF has no document-model form upstream (it converts straight to Markdown),
-  so PDF extraction through this backend is text only. Configure
-  ``backends.pdf: native`` to keep per-page image extraction for PDFs.
+  so PDF extraction through this backend is text only. The bundled default
+  keeps ``backends.pdf: native`` for that reason.
 """
 
 from __future__ import annotations
@@ -26,8 +26,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from anydoc import Asset
+    from anydoc import Asset, Document
 
+from obsidian_import.anydoc_placement import place_media_embeds
 from obsidian_import.config import MediaConfig
 from obsidian_import.exceptions import BackendNotAvailableError, ExtractionError
 from obsidian_import.extraction_result import ExtractionResult, MediaFile
@@ -62,14 +63,18 @@ def _extract_anydoc(path: Path, media_config: MediaConfig) -> ExtractionResult:
 
     text = _convert_to_markdown(data, doc_format, path)
 
-    media_files: list[MediaFile] = []
+    media_by_asset_id: dict[int, MediaFile] = {}
     if media_config.extract_images:
-        media_files = _extract_assets(data, doc_format, path, media_config)
+        document = _read_document_model(data, doc_format, path)
+        if document is not None:
+            media_by_asset_id = _extract_assets(document, path, media_config)
+            if media_by_asset_id:
+                text = place_media_embeds(text, document, media_by_asset_id, path.stem)
 
     if not text.strip():
         text = f"*No text content extracted from `{path.name}`.*"
 
-    return ExtractionResult(markdown=text, media_files=tuple(media_files))
+    return ExtractionResult(markdown=text, media_files=tuple(media_by_asset_id.values()))
 
 
 def _convert_to_markdown(data: bytes, doc_format: str | None, path: Path) -> str:
@@ -86,16 +91,16 @@ def _convert_to_markdown(data: bytes, doc_format: str | None, path: Path) -> str
         ) from exc
 
 
-def _extract_assets(data: bytes, doc_format: str | None, path: Path, media_config: MediaConfig) -> list[MediaFile]:
-    """Extract embedded image assets via anydoc's document model."""
+def _read_document_model(data: bytes, doc_format: str | None, path: Path) -> Document | None:
+    """Parse the document model that carries the embedded images, or None if unavailable."""
     import anydoc
 
     if doc_format in _FORMATS_WITHOUT_DOCUMENT_MODEL:
         log.info("anydoc exposes no document model for %s; extracting text only from %s", doc_format, path)
-        return []
+        return None
 
     try:
-        document = anydoc.to_document(data, doc_format)
+        return anydoc.to_document(data, doc_format)
     except anydoc.ConvertError as exc:
         log.warning(
             "anydoc could not read the document model of %s (%s); text was extracted without images. "
@@ -103,9 +108,12 @@ def _extract_assets(data: bytes, doc_format: str | None, path: Path, media_confi
             path,
             exc,
         )
-        return []
+        return None
 
-    media_files: list[MediaFile] = []
+
+def _extract_assets(document: Document, path: Path, media_config: MediaConfig) -> dict[int, MediaFile]:
+    """Save the document's embedded images, keyed by the asset id that references them."""
+    media_by_asset_id: dict[int, MediaFile] = {}
     image_assets = [a for a in document.assets if a.media_type.startswith(_IMAGE_MEDIA_TYPE_PREFIX)]
     for index, asset in enumerate(image_assets, 1):
         filename = generate_media_filename(_ASSET_FILENAME_CONTEXT, index, f".{media_config.image_format}")
@@ -116,9 +124,9 @@ def _extract_assets(data: bytes, doc_format: str | None, path: Path, media_confi
             f"asset {asset.id} ({asset.media_type}) from {path} via anydoc",
         )
         if media_file is not None:
-            media_files.append(media_file)
+            media_by_asset_id[asset.id] = media_file
 
-    return media_files
+    return media_by_asset_id
 
 
 def _make_asset_reader(asset: Asset) -> Callable[[], bytes | None]:

--- a/obsidian_import/backends/anydoc.py
+++ b/obsidian_import/backends/anydoc.py
@@ -1,0 +1,130 @@
+"""Document extraction using anydoc, the default backend for document formats.
+
+anydoc (https://github.com/firecrawl/anydoc) is a Rust converter that turns
+PDF, Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, and CSV inputs into
+GitHub-Flavored Markdown. It ships as a compiled wheel with no model
+downloads, so it is a required dependency rather than an extra.
+
+Two behaviors of the upstream library shape this backend:
+
+- Embedded images are absent from anydoc's Markdown: an embedded image renders
+  as its alt text, or as nothing when it has none, and the document model
+  carries no position for an asset. There is therefore no in-text reference to
+  rewrite into a wikilink; extracted images are returned as media files and
+  ``extract_file`` embeds the unreferenced ones at the end of the note.
+- PDF has no document-model form upstream (it converts straight to Markdown),
+  so PDF extraction through this backend is text only. Configure
+  ``backends.pdf: native`` to keep per-page image extraction for PDFs.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from anydoc import Asset
+
+from obsidian_import.config import MediaConfig
+from obsidian_import.exceptions import BackendNotAvailableError, ExtractionError
+from obsidian_import.extraction_result import ExtractionResult, MediaFile
+from obsidian_import.media import attempt_save_image, generate_media_filename
+from obsidian_import.timeout import TimeoutContext, run_with_timeout
+
+log = logging.getLogger(__name__)
+
+_ASSET_FILENAME_CONTEXT = "asset"
+_IMAGE_MEDIA_TYPE_PREFIX = "image/"
+_FORMATS_WITHOUT_DOCUMENT_MODEL = frozenset({"pdf"})
+
+
+def extract(path: Path, timeout_seconds: int, isolation: str, media_config: MediaConfig) -> ExtractionResult:
+    """Extract text and embedded images from a document using anydoc."""
+    if importlib.util.find_spec("anydoc") is None:
+        raise BackendNotAvailableError(
+            "anydoc is not installed. Install with: pip install firecrawl-anydoc "
+            "(it ships as a required dependency of obsidian-import)"
+        )
+
+    ctx = TimeoutContext(timeout_seconds=timeout_seconds, label="anydoc", path=path, isolation=isolation)
+    return run_with_timeout(_extract_anydoc, (path, media_config), ctx)
+
+
+def _extract_anydoc(path: Path, media_config: MediaConfig) -> ExtractionResult:
+    """Internal anydoc extraction logic (module-level for process isolation)."""
+    import anydoc
+
+    data = path.read_bytes()
+    doc_format = anydoc.format_from_bytes(data) or anydoc.format_from_extension(path.suffix)
+
+    text = _convert_to_markdown(data, doc_format, path)
+
+    media_files: list[MediaFile] = []
+    if media_config.extract_images:
+        media_files = _extract_assets(data, doc_format, path, media_config)
+
+    if not text.strip():
+        text = f"*No text content extracted from `{path.name}`.*"
+
+    return ExtractionResult(markdown=text, media_files=tuple(media_files))
+
+
+def _convert_to_markdown(data: bytes, doc_format: str | None, path: Path) -> str:
+    """Convert document bytes to markdown, translating anydoc failures."""
+    import anydoc
+
+    try:
+        return anydoc.to_markdown_bytes(data, doc_format)
+    except anydoc.ConvertError as exc:
+        raise ExtractionError(
+            f"anydoc could not convert {path} (detected format: {doc_format or 'unrecognized'}): {exc}. "
+            "Set a different backend for this extension under the `backends` config section, "
+            "or convert the file to a supported format first."
+        ) from exc
+
+
+def _extract_assets(data: bytes, doc_format: str | None, path: Path, media_config: MediaConfig) -> list[MediaFile]:
+    """Extract embedded image assets via anydoc's document model."""
+    import anydoc
+
+    if doc_format in _FORMATS_WITHOUT_DOCUMENT_MODEL:
+        log.info("anydoc exposes no document model for %s; extracting text only from %s", doc_format, path)
+        return []
+
+    try:
+        document = anydoc.to_document(data, doc_format)
+    except anydoc.ConvertError as exc:
+        log.warning(
+            "anydoc could not read the document model of %s (%s); text was extracted without images. "
+            "Set backends for this extension to a native backend to recover images.",
+            path,
+            exc,
+        )
+        return []
+
+    media_files: list[MediaFile] = []
+    image_assets = [a for a in document.assets if a.media_type.startswith(_IMAGE_MEDIA_TYPE_PREFIX)]
+    for index, asset in enumerate(image_assets, 1):
+        filename = generate_media_filename(_ASSET_FILENAME_CONTEXT, index, f".{media_config.image_format}")
+        media_file = attempt_save_image(
+            _make_asset_reader(asset),
+            filename,
+            media_config,
+            f"asset {asset.id} ({asset.media_type}) from {path} via anydoc",
+        )
+        if media_file is not None:
+            media_files.append(media_file)
+
+    return media_files
+
+
+def _make_asset_reader(asset: Asset) -> Callable[[], bytes | None]:
+    """Return a callable yielding the raw bytes of an anydoc asset."""
+
+    def _read() -> bytes | None:
+        return asset.data
+
+    return _read

--- a/obsidian_import/cli.py
+++ b/obsidian_import/cli.py
@@ -18,6 +18,10 @@ from obsidian_import.registry import check_backend_available
 
 log = logging.getLogger(__name__)
 
+# Backends whose absence makes the shipped default config unusable; the
+# markitdown and docling extras are opt-in and only reported by `doctor`.
+_REQUIRED_BACKENDS: tuple[str, ...] = ("native", "anydoc")
+
 
 def _resolve_config(config_path: str | None) -> ImportConfig:
     """Load config from path or use defaults."""
@@ -135,6 +139,7 @@ def doctor() -> None:
         ("native (json)", "native", ".json"),
         ("native (yaml)", "native", ".yaml"),
         ("native (image)", "native", ".png"),
+        ("anydoc", "anydoc", ".pdf"),
         ("markitdown", "markitdown", ".pdf"),
         ("docling", "docling", ".pdf"),
     ]
@@ -144,7 +149,7 @@ def doctor() -> None:
         available, message = check_backend_available(backend, ext)
         status = "OK" if available else "MISSING"
         click.echo(f"  {label:20s}  [{status}]  {message}")
-        if not available and backend == "native":
+        if not available and backend in _REQUIRED_BACKENDS:
             all_ok = False
 
     tools = {

--- a/obsidian_import/defaults/default.yaml
+++ b/obsidian_import/defaults/default.yaml
@@ -12,15 +12,22 @@ output:
     - extracted_at
     - page_count
 
-# anydoc is the default document converter: it handles PDF, Word, PowerPoint,
-# Excel, OpenDocument, RTF, EPUB, and CSV, and ships as a required dependency.
+# anydoc is the default document converter: it handles Word, PowerPoint, Excel,
+# OpenDocument, RTF, EPUB, PDF, and CSV, and ships as a required dependency.
 # Formats it does not read (JSON, YAML, images) stay on the native backends,
-# and HTML stays on markitdown. Two anydoc trade-offs vs. the native backends:
-# PDFs come out text-only (anydoc exposes no image model for PDF), and
-# extraction.xlsx_max_rows_per_sheet does not apply. Set a key back to
-# `native` to get those behaviors for that format.
+# and HTML stays on markitdown.
+#
+# PDF is the one document format anydoc is not the default for. anydoc parses
+# PDF straight to Markdown and exposes no document model for it, which costs
+# three things the native PDF backend provides: embedded page images, the
+# `## Page N` headings, and the page_count frontmatter field derived from them.
+# It also does no OCR, so a scanned PDF fails instead of yielding an empty
+# note. Set `pdf: anydoc` to convert PDFs with anydoc anyway.
+#
+# One more anydoc trade-off: extraction.xlsx_max_rows_per_sheet does not apply
+# to it. Set `xlsx: native` to cap the rows read per sheet.
 backends:
-  pdf: anydoc
+  pdf: native
   docx: anydoc
   pptx: anydoc
   xlsx: anydoc

--- a/obsidian_import/defaults/default.yaml
+++ b/obsidian_import/defaults/default.yaml
@@ -12,17 +12,24 @@ output:
     - extracted_at
     - page_count
 
+# anydoc is the default document converter: it handles PDF, Word, PowerPoint,
+# Excel, OpenDocument, RTF, EPUB, and CSV, and ships as a required dependency.
+# Formats it does not read (JSON, YAML, images) stay on the native backends,
+# and HTML stays on markitdown. Two anydoc trade-offs vs. the native backends:
+# PDFs come out text-only (anydoc exposes no image model for PDF), and
+# extraction.xlsx_max_rows_per_sheet does not apply. Set a key back to
+# `native` to get those behaviors for that format.
 backends:
-  pdf: native
-  docx: native
-  pptx: native
-  xlsx: native
-  csv: native
+  pdf: anydoc
+  docx: anydoc
+  pptx: anydoc
+  xlsx: anydoc
+  csv: anydoc
   json: native
   yaml: native
   image: native
   html: markitdown
-  default: native
+  default: anydoc
 
 extraction:
   timeout_seconds: 120

--- a/obsidian_import/registry.py
+++ b/obsidian_import/registry.py
@@ -68,7 +68,10 @@ _BACKEND_MODULES: dict[str, str | dict[str, str]] = {
     },
     "markitdown": "obsidian_import.backends.markitdown",
     "docling": "obsidian_import.backends.docling",
+    "anydoc": "obsidian_import.backends.anydoc",
 }
+
+_SINGLE_MODULE_BACKENDS: tuple[str, ...] = ("markitdown", "docling", "anydoc")
 
 
 def _resolve_module_path(backend_name: str, extension: str) -> str:
@@ -86,7 +89,7 @@ def _resolve_module_path(backend_name: str, extension: str) -> str:
                 f"Supported native extensions: {', '.join(native_map.keys())}"
             )
         module_path = native_map[extension]
-    elif backend_name in ("markitdown", "docling"):
+    elif backend_name in _SINGLE_MODULE_BACKENDS:
         module_path = _BACKEND_MODULES[backend_name]
         if not isinstance(module_path, str):
             raise UnsupportedFormatError(f"Internal: backend module path misconfigured for '{backend_name}'")
@@ -112,6 +115,33 @@ def get_backend_module(extension: str, backends: BackendsConfig) -> types.Module
     return importlib.import_module(module_path)
 
 
+# Capability gaps already reported, as (backend, extension, options). A gap is
+# a property of the configuration, not of the file, so a batch run must report
+# each one once instead of once per file. Reset with
+# reset_capability_gap_warnings() when a process re-reads its config.
+_reported_capability_gaps: set[tuple[str, str, tuple[str, ...]]] = set()
+
+
+def reset_capability_gap_warnings() -> None:
+    """Forget which capability gaps have been reported, so they warn again."""
+    _reported_capability_gaps.clear()
+
+
+def _warn_capability_gap(backend_name: str, extension: str, unsupported: set[str]) -> None:
+    """Warn that a backend ignores config options, once per backend/extension/options."""
+    options = tuple(sorted(unsupported))
+    key = (backend_name, extension, options)
+    if key in _reported_capability_gaps:
+        return
+    _reported_capability_gaps.add(key)
+    log.warning(
+        "backend '%s' does not support %s for %s; these options are ignored",
+        backend_name,
+        list(options),
+        extension,
+    )
+
+
 def extract_with_backend(
     path: Path,
     context: ExtractionContext,
@@ -133,13 +163,7 @@ def extract_with_backend(
     accepted = set(sig.parameters.keys()) - {"path", "timeout_seconds", "media_config", "isolation"}
     unsupported = {k for k in kwargs if k not in accepted}
     if unsupported:
-        backend_name = module.__name__.split(".")[-1]
-        log.warning(
-            "backend '%s' does not support %s for %s; these options are ignored",
-            backend_name,
-            sorted(unsupported),
-            extension,
-        )
+        _warn_capability_gap(module.__name__.split(".")[-1], extension, unsupported)
     call_kwargs = {k: v for k, v in kwargs.items() if k not in unsupported}
     if "media_config" in sig.parameters:
         call_kwargs["media_config"] = context.media_config

--- a/pixi.lock
+++ b/pixi.lock
@@ -193,6 +193,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/0b/d2943ee6b5eab1a673fe96333070b67232e819cc39728294a7034176006f/firecrawl_anydoc-0.1.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dd/34/b6f19941adcdaf415b5e8a8d577499f5b6a76b59cbae37f9b125a9ffe9f2/polyfactory-3.3.0-py3-none-any.whl
@@ -356,6 +357,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/af/342a3fcaab2d6cc80ecf636cbab9e3b29205467c21cf1ec6dbf9e2a77814/firecrawl_anydoc-0.1.6-cp310-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl
@@ -1012,6 +1014,7 @@ packages:
 - pypi: ./
   name: obsidian-import
   requires_dist:
+  - firecrawl-anydoc>=0.1.6,<0.2
   - pyyaml>=6.0,<7
   - click>=8.3.3,<9
   - pdfplumber>=0.11,<1
@@ -3653,6 +3656,11 @@ packages:
   - trove-classifiers>=2024.10.12 ; extra == 'tests'
   - defusedxml ; extra == 'xmp'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ca/af/342a3fcaab2d6cc80ecf636cbab9e3b29205467c21cf1ec6dbf9e2a77814/firecrawl_anydoc-0.1.6-cp310-abi3-macosx_11_0_arm64.whl
+  name: firecrawl-anydoc
+  version: 0.1.6
+  sha256: f102e87c004bcf6de979a1697776774454f814d85893e47fedc58fdf838a2f9b
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
   name: iniconfig
   version: 2.3.0
@@ -3811,6 +3819,11 @@ packages:
   - lxml>=3.1.0
   - typing-extensions>=4.9.0
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/db/0b/d2943ee6b5eab1a673fe96333070b67232e819cc39728294a7034176006f/firecrawl_anydoc-0.1.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: firecrawl-anydoc
+  version: 0.1.6
+  sha256: d3e65bbe6709a3a02dc4faf6af8b387016ac4ac2a5b38a70a9f950a8efa492d0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
   name: cfgv
   version: 3.5.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,6 +13,7 @@ setuptools = ">=78.1.1,<79"
 
 [pypi-dependencies]
 obsidian-import = {path = ".", editable = true}
+firecrawl-anydoc = ">=0.1.6,<0.2"
 pyyaml = ">=6.0,<7"
 click = ">=8.3.3,<9"
 pdfplumber = ">=0.11,<1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Topic :: Office/Business",
 ]
 dependencies = [
+    "firecrawl-anydoc>=0.1.6,<0.2",
     "pyyaml>=6.0,<7",
     "click>=8.3.3,<9",
     "pdfplumber>=0.11,<1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,17 @@ import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
 from PIL import Image
 
 from obsidian_import.config import MediaConfig
+from obsidian_import.registry import reset_capability_gap_warnings
+
+
+@pytest.fixture(autouse=True)
+def _forget_capability_gap_warnings():
+    """Keep the once-per-config capability warning independent of test order."""
+    reset_capability_gap_warnings()
 
 
 def make_test_docx(path: Path, text: str) -> None:

--- a/tests/test_anydoc.py
+++ b/tests/test_anydoc.py
@@ -1,0 +1,284 @@
+"""Tests for the anydoc backend, exercised against real anydoc conversions."""
+
+import dataclasses
+import io
+import logging
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from conftest import make_test_media_config
+from hypothesis import given
+from hypothesis import strategies as st
+from PIL import Image
+
+from obsidian_import import extract_file
+from obsidian_import.backends.anydoc import extract
+from obsidian_import.config import default_config
+from obsidian_import.exceptions import BackendNotAvailableError, ExtractionError
+
+_TEST_MEDIA_CONFIG = make_test_media_config()
+_NO_IMAGE_MEDIA_CONFIG = dataclasses.replace(_TEST_MEDIA_CONFIG, extract_images=False)
+
+_CONTENT_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml"
+    ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"""
+
+_ROOT_RELS = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+    Target="word/document.xml"/>
+</Relationships>"""
+
+_IMAGE_REL = (
+    '<Relationship Id="rId{index}" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" '
+    'Target="media/image{index}.png"/>'
+)
+
+
+def _doc_rels(image_count: int) -> str:
+    relationships = "".join(_IMAGE_REL.format(index=i) for i in range(1, image_count + 1))
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+        f"{relationships}</Relationships>"
+    )
+
+
+def _png_bytes(color: str) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (12, 8), color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _document_xml(text: str, image_count: int) -> str:
+    pictures = "".join(
+        f"""<w:p><w:r><w:drawing><wp:inline>
+        <wp:docPr id="{i}" name="Picture {i}" descr="figure {i}"/>
+        <a:graphic><a:graphicData><a:blip r:embed="rId{i}"/></a:graphicData></a:graphic>
+        </wp:inline></w:drawing></w:r></w:p>"""
+        for i in range(1, image_count + 1)
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+            xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:t>{text}</w:t></w:r></w:p>
+    {pictures}
+  </w:body>
+</w:document>"""
+
+
+def _write_docx(path: Path, text: str, image_colors: tuple[str, ...]) -> Path:
+    """Write a valid OOXML package with one paragraph and one image per color."""
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("[Content_Types].xml", _CONTENT_TYPES)
+        zf.writestr("_rels/.rels", _ROOT_RELS)
+        zf.writestr("word/_rels/document.xml.rels", _doc_rels(len(image_colors)))
+        zf.writestr("word/document.xml", _document_xml(text, len(image_colors)))
+        for i, color in enumerate(image_colors, 1):
+            zf.writestr(f"word/media/image{i}.png", _png_bytes(color))
+    return path
+
+
+def _write_pdf(path: Path, text: str) -> Path:
+    """Write a minimal single-page PDF holding one text run."""
+    stream = f"BT /F1 24 Tf 20 100 Td ({text}) Tj ET".encode()
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R "
+        b"/Resources << /Font << /F1 5 0 R >> >> >>",
+        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+    out = bytearray(b"%PDF-1.4\n")
+    offsets: list[int] = []
+    for i, body in enumerate(objects, 1):
+        offsets.append(len(out))
+        out += f"{i} 0 obj\n".encode() + body + b"\nendobj\n"
+    xref_at = len(out)
+    out += f"xref\n0 {len(objects) + 1}\n".encode()
+    out += b"0000000000 65535 f \n"
+    for offset in offsets:
+        out += f"{offset:010d} 00000 n \n".encode()
+    out += f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_at}\n%%EOF\n".encode()
+    path.write_bytes(bytes(out))
+    return path
+
+
+class TestAnydocText:
+    def test_extracts_docx_text(self, tmp_path):
+        docx = _write_docx(tmp_path / "report.docx", "Quarterly summary", ())
+
+        result = extract(docx, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+        assert "Quarterly summary" in result.markdown
+        assert result.media_files == ()
+
+    def test_extracts_csv_as_markdown_table(self, tmp_path):
+        csv = tmp_path / "rows.csv"
+        csv.write_text("name,count\nwidget,3\n")
+
+        result = extract(csv, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+        assert "| name | count |" in result.markdown
+        assert "| widget | 3 |" in result.markdown
+
+    @given(
+        rows=st.lists(
+            st.lists(
+                st.text(alphabet=st.characters(min_codepoint=97, max_codepoint=122), min_size=1, max_size=6),
+                min_size=1,
+                max_size=4,
+            ),
+            min_size=2,
+            max_size=6,
+        )
+    )
+    def test_csv_rows_survive_conversion(self, tmp_path_factory, rows):
+        # Every CSV row reaches the markdown table as its own row, in order.
+        # Which row becomes the header is anydoc's call, so the assertion is
+        # on content preservation rather than on the header line.
+        width = len(rows[0])
+        square_rows = [row[:width] + ["x"] * (width - len(row)) for row in rows]
+        csv = tmp_path_factory.mktemp("csv") / "rows.csv"
+        csv.write_text("\n".join(",".join(row) for row in square_rows) + "\n")
+
+        result = extract(csv, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+        rendered = [line for line in result.markdown.splitlines() if line.startswith("|")]
+        # Cells are lowercase letters only, so a dash marks the separator row.
+        assert sum("---" in line for line in rendered) == 1
+        data_lines = [line for line in rendered if "---" not in line]
+        assert data_lines[-len(square_rows) :] == ["| " + " | ".join(row) + " |" for row in square_rows]
+
+    def test_extracts_pdf_text_without_media(self, tmp_path):
+        pdf = _write_pdf(tmp_path / "note.pdf", "Hello PDF")
+
+        result = extract(pdf, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+        assert "Hello PDF" in result.markdown
+        assert result.media_files == ()
+
+    def test_empty_document_gets_placeholder(self, tmp_path):
+        csv = tmp_path / "empty.csv"
+        csv.write_text("")
+
+        result = extract(csv, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+        assert "No text content extracted" in result.markdown
+        assert "empty.csv" in result.markdown
+
+    def test_extracts_under_process_isolation(self, tmp_path):
+        docx = _write_docx(tmp_path / "isolated.docx", "Runs in a child process", ())
+
+        result = extract(docx, timeout_seconds=120, isolation="process", media_config=_TEST_MEDIA_CONFIG)
+
+        assert "Runs in a child process" in result.markdown
+
+
+class TestAnydocMedia:
+    def test_embedded_images_become_media_files(self, tmp_path):
+        docx = _write_docx(tmp_path / "deck.docx", "With figures", ("red", "blue"))
+
+        result = extract(docx, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+        assert len(result.media_files) == 2
+        assert [mf.filename for mf in result.media_files] == ["asset_img1.png", "asset_img2.png"]
+        for media_file in result.media_files:
+            assert media_file.media_type == "image"
+            assert media_file.source_path.read_bytes()
+
+    def test_images_disabled_yields_text_only(self, tmp_path):
+        docx = _write_docx(tmp_path / "deck.docx", "With figures", ("red",))
+
+        result = extract(docx, timeout_seconds=30, isolation="thread", media_config=_NO_IMAGE_MEDIA_CONFIG)
+
+        assert result.media_files == ()
+        assert "![[" not in result.markdown
+
+    def test_unreadable_document_model_keeps_text(self, tmp_path, caplog):
+        import anydoc
+
+        docx = _write_docx(tmp_path / "deck.docx", "Text survives", ("red",))
+
+        with (
+            patch("anydoc.to_document", side_effect=anydoc.MalformedError("unreadable part")),
+            caplog.at_level(logging.WARNING, logger="obsidian_import.backends.anydoc"),
+        ):
+            result = extract(docx, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+        assert result.media_files == ()
+        assert "Text survives" in result.markdown
+        assert any("document model" in record.getMessage() for record in caplog.records)
+
+    def test_unreadable_image_is_skipped_with_text_kept(self, tmp_path):
+        docx = _write_docx(tmp_path / "broken.docx", "Text survives", ("red",))
+        tiny_pixel_config = dataclasses.replace(_TEST_MEDIA_CONFIG, image_max_pixels=1)
+
+        result = extract(docx, timeout_seconds=30, isolation="thread", media_config=tiny_pixel_config)
+
+        assert result.media_files == ()
+        assert "Text survives" in result.markdown
+
+
+class TestAnydocFailures:
+    def test_unsupported_format_raises_extraction_error(self, tmp_path):
+        unknown = tmp_path / "notes.txt"
+        unknown.write_text("plain text has no anydoc parser")
+
+        with pytest.raises(ExtractionError, match="anydoc could not convert"):
+            extract(unknown, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+    def test_malformed_document_raises_extraction_error(self, tmp_path):
+        broken = tmp_path / "corrupt.docx"
+        broken.write_bytes(b"this is not a zip archive")
+
+        with pytest.raises(ExtractionError, match="anydoc could not convert"):
+            extract(broken, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+    def test_missing_file_propagates(self, tmp_path):
+        with pytest.raises(ExtractionError, match="FileNotFoundError|No such file"):
+            extract(tmp_path / "absent.docx", timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+    def test_missing_dependency_raises(self, tmp_path):
+        with (
+            patch("obsidian_import.backends.anydoc.importlib.util.find_spec", return_value=None),
+            pytest.raises(BackendNotAvailableError, match="anydoc is not installed"),
+        ):
+            extract(tmp_path / "any.docx", timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+
+class TestAnydocThroughDefaultConfig:
+    """The shipped default config routes documents through anydoc."""
+
+    def test_docx_extraction_embeds_images_in_the_note(self, tmp_path):
+        docx = _write_docx(tmp_path / "deck.docx", "With figures", ("red", "blue"))
+
+        document = extract_file(docx, default_config())
+
+        assert "With figures" in document.markdown
+        assert len(document.media_files) == 2
+        for media_file in document.media_files:
+            assert f"![[deck/{media_file.filename}]]" in document.markdown
+
+    @pytest.mark.parametrize("stem", ["book.epub", "memo.rtf", "sheet.ods"])
+    def test_formats_without_a_config_key_reach_anydoc(self, tmp_path, stem):
+        # These extensions have no `backends` key, so `default: anydoc` is what
+        # dispatches them; the placeholder content makes anydoc reject them,
+        # which proves the file reached the anydoc backend.
+        unreadable = tmp_path / stem
+        unreadable.write_bytes(b"placeholder")
+
+        with pytest.raises(ExtractionError, match="anydoc could not convert"):
+            extract_file(unreadable, default_config())

--- a/tests/test_anydoc.py
+++ b/tests/test_anydoc.py
@@ -58,35 +58,51 @@ def _png_bytes(color: str) -> bytes:
     return buf.getvalue()
 
 
-def _document_xml(text: str, image_count: int) -> str:
-    pictures = "".join(
-        f"""<w:p><w:r><w:drawing><wp:inline>
-        <wp:docPr id="{i}" name="Picture {i}" descr="figure {i}"/>
-        <a:graphic><a:graphicData><a:blip r:embed="rId{i}"/></a:graphicData></a:graphic>
-        </wp:inline></w:drawing></w:r></w:p>"""
-        for i in range(1, image_count + 1)
+def _paragraph_xml(text: str) -> str:
+    return f"<w:p><w:r><w:t>{text}</w:t></w:r></w:p>"
+
+
+def _picture_xml(image_number: int) -> str:
+    return (
+        f"<w:p><w:r><w:drawing><wp:inline>"
+        f'<wp:docPr id="{image_number}" name="Picture {image_number}"/>'
+        f'<a:graphic><a:graphicData><a:blip r:embed="rId{image_number}"/></a:graphicData></a:graphic>'
+        f"</wp:inline></w:drawing></w:r></w:p>"
     )
+
+
+def _document_xml(body: str) -> str:
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
             xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
-  <w:body>
-    <w:p><w:r><w:t>{text}</w:t></w:r></w:p>
-    {pictures}
-  </w:body>
+  <w:body>{body}</w:body>
 </w:document>"""
 
 
-def _write_docx(path: Path, text: str, image_colors: tuple[str, ...]) -> Path:
-    """Write a valid OOXML package with one paragraph and one image per color."""
+def _write_docx(path: Path, items: tuple[tuple[str, str], ...]) -> Path:
+    """Write a valid OOXML package from ("text", value) and ("image", color) items, in order.
+
+    Repeating a color reuses that image part, the way a document that embeds the
+    same picture twice does.
+    """
+    body_parts: list[str] = []
+    part_numbers: dict[str, int] = {}
+    for kind, value in items:
+        if kind == "text":
+            body_parts.append(_paragraph_xml(value))
+        else:
+            part_numbers.setdefault(value, len(part_numbers) + 1)
+            body_parts.append(_picture_xml(part_numbers[value]))
+
     with zipfile.ZipFile(path, "w") as zf:
         zf.writestr("[Content_Types].xml", _CONTENT_TYPES)
         zf.writestr("_rels/.rels", _ROOT_RELS)
-        zf.writestr("word/_rels/document.xml.rels", _doc_rels(len(image_colors)))
-        zf.writestr("word/document.xml", _document_xml(text, len(image_colors)))
-        for i, color in enumerate(image_colors, 1):
-            zf.writestr(f"word/media/image{i}.png", _png_bytes(color))
+        zf.writestr("word/_rels/document.xml.rels", _doc_rels(len(part_numbers)))
+        zf.writestr("word/document.xml", _document_xml("".join(body_parts)))
+        for color, number in part_numbers.items():
+            zf.writestr(f"word/media/image{number}.png", _png_bytes(color))
     return path
 
 
@@ -118,7 +134,7 @@ def _write_pdf(path: Path, text: str) -> Path:
 
 class TestAnydocText:
     def test_extracts_docx_text(self, tmp_path):
-        docx = _write_docx(tmp_path / "report.docx", "Quarterly summary", ())
+        docx = _write_docx(tmp_path / "report.docx", (("text", "Quarterly summary"),))
 
         result = extract(docx, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
 
@@ -180,7 +196,7 @@ class TestAnydocText:
         assert "empty.csv" in result.markdown
 
     def test_extracts_under_process_isolation(self, tmp_path):
-        docx = _write_docx(tmp_path / "isolated.docx", "Runs in a child process", ())
+        docx = _write_docx(tmp_path / "isolated.docx", (("text", "Runs in a child process"),))
 
         result = extract(docx, timeout_seconds=120, isolation="process", media_config=_TEST_MEDIA_CONFIG)
 
@@ -189,7 +205,7 @@ class TestAnydocText:
 
 class TestAnydocMedia:
     def test_embedded_images_become_media_files(self, tmp_path):
-        docx = _write_docx(tmp_path / "deck.docx", "With figures", ("red", "blue"))
+        docx = _write_docx(tmp_path / "deck.docx", (("text", "With figures"), ("image", "red"), ("image", "blue")))
 
         result = extract(docx, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
 
@@ -199,8 +215,42 @@ class TestAnydocMedia:
             assert media_file.media_type == "image"
             assert media_file.source_path.read_bytes()
 
+    def test_images_are_embedded_where_they_sit_in_the_document(self, tmp_path):
+        docx = _write_docx(
+            tmp_path / "deck.docx",
+            (
+                ("text", "Text before the figure."),
+                ("image", "red"),
+                ("text", "Text between the figures."),
+                ("image", "blue"),
+                ("text", "Text after the figures."),
+            ),
+        )
+
+        result = extract(docx, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+        assert result.markdown == (
+            "Text before the figure.\n\n"
+            "![[deck/asset_img1.png]]\n\n"
+            "Text between the figures.\n\n"
+            "![[deck/asset_img2.png]]\n\n"
+            "Text after the figures.\n"
+        )
+
+    def test_repeated_image_is_embedded_at_each_position(self, tmp_path):
+        # anydoc deduplicates assets by content: one media file, two embeds.
+        docx = _write_docx(
+            tmp_path / "deck.docx",
+            (("image", "red"), ("text", "Between the two copies."), ("image", "red")),
+        )
+
+        result = extract(docx, timeout_seconds=30, isolation="thread", media_config=_TEST_MEDIA_CONFIG)
+
+        assert len(result.media_files) == 1
+        assert result.markdown == ("![[deck/asset_img1.png]]\n\nBetween the two copies.\n\n![[deck/asset_img1.png]]\n")
+
     def test_images_disabled_yields_text_only(self, tmp_path):
-        docx = _write_docx(tmp_path / "deck.docx", "With figures", ("red",))
+        docx = _write_docx(tmp_path / "deck.docx", (("text", "With figures"), ("image", "red")))
 
         result = extract(docx, timeout_seconds=30, isolation="thread", media_config=_NO_IMAGE_MEDIA_CONFIG)
 
@@ -210,7 +260,7 @@ class TestAnydocMedia:
     def test_unreadable_document_model_keeps_text(self, tmp_path, caplog):
         import anydoc
 
-        docx = _write_docx(tmp_path / "deck.docx", "Text survives", ("red",))
+        docx = _write_docx(tmp_path / "deck.docx", (("text", "Text survives"), ("image", "red")))
 
         with (
             patch("anydoc.to_document", side_effect=anydoc.MalformedError("unreadable part")),
@@ -223,7 +273,7 @@ class TestAnydocMedia:
         assert any("document model" in record.getMessage() for record in caplog.records)
 
     def test_unreadable_image_is_skipped_with_text_kept(self, tmp_path):
-        docx = _write_docx(tmp_path / "broken.docx", "Text survives", ("red",))
+        docx = _write_docx(tmp_path / "broken.docx", (("text", "Text survives"), ("image", "red")))
         tiny_pixel_config = dataclasses.replace(_TEST_MEDIA_CONFIG, image_max_pixels=1)
 
         result = extract(docx, timeout_seconds=30, isolation="thread", media_config=tiny_pixel_config)
@@ -263,7 +313,7 @@ class TestAnydocThroughDefaultConfig:
     """The shipped default config routes documents through anydoc."""
 
     def test_docx_extraction_embeds_images_in_the_note(self, tmp_path):
-        docx = _write_docx(tmp_path / "deck.docx", "With figures", ("red", "blue"))
+        docx = _write_docx(tmp_path / "deck.docx", (("text", "With figures"), ("image", "red"), ("image", "blue")))
 
         document = extract_file(docx, default_config())
 

--- a/tests/test_anydoc_placement.py
+++ b/tests/test_anydoc_placement.py
@@ -1,0 +1,259 @@
+"""Tests for splicing anydoc media embeds into anydoc's markdown."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from obsidian_import.anydoc_placement import _block_spans, place_media_embeds
+from obsidian_import.extraction_result import MediaFile
+
+
+def _media(filename: str) -> MediaFile:
+    return MediaFile(source_path=Path("/tmp") / filename, filename=filename, media_type="image")
+
+
+def _text(value: str) -> SimpleNamespace:
+    return SimpleNamespace(kind="text", text=value, alt=None, content=None, source=None)
+
+
+def _image(asset_id: int, alt: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        kind="image",
+        text=None,
+        alt=alt,
+        content=None,
+        source=SimpleNamespace(kind="asset", asset_id=asset_id, url=None),
+    )
+
+
+def _block(kind: str, content: list | None = None, **fields) -> SimpleNamespace:
+    return SimpleNamespace(
+        kind=kind,
+        content=content,
+        blocks=fields.get("blocks"),
+        list=fields.get("list"),
+        table=fields.get("table"),
+        lang=fields.get("lang"),
+        text=fields.get("text"),
+        level=fields.get("level"),
+    )
+
+
+def _document(blocks: list) -> SimpleNamespace:
+    return SimpleNamespace(blocks=blocks, assets=[], notes=[])
+
+
+class TestBlockSpans:
+    def test_splits_on_blank_lines(self):
+        markdown = "First block\n\nSecond block\n"
+
+        spans = _block_spans(markdown)
+
+        assert [markdown[start:end] for start, end in spans] == ["First block", "Second block"]
+
+    def test_keeps_fenced_code_whole(self):
+        markdown = "Intro\n\n```python\na = 1\n\nb = 2\n```\n\nOutro\n"
+
+        spans = _block_spans(markdown)
+
+        assert [markdown[start:end] for start, end in spans] == [
+            "Intro",
+            "```python\na = 1\n\nb = 2\n```",
+            "Outro",
+        ]
+
+    def test_multiline_table_is_one_block(self):
+        markdown = "| a | b |\n| --- | --- |\n| 1 | 2 |\n"
+
+        spans = _block_spans(markdown)
+
+        assert len(spans) == 1
+
+    @given(
+        paragraphs=st.lists(
+            st.text(alphabet=st.characters(min_codepoint=97, max_codepoint=122), min_size=1, max_size=10),
+            min_size=1,
+            max_size=6,
+        )
+    )
+    def test_spans_reconstruct_the_paragraphs(self, paragraphs):
+        markdown = "\n\n".join(paragraphs) + "\n"
+
+        spans = _block_spans(markdown)
+
+        assert [markdown[start:end] for start, end in spans] == paragraphs
+
+
+class TestPlaceMediaEmbeds:
+    def test_image_only_block_lands_between_its_neighbours(self):
+        document = _document(
+            [
+                _block("paragraph", [_text("Before the figure.")]),
+                _block("paragraph", [_image(0)]),
+                _block("paragraph", [_text("After the figure.")]),
+            ]
+        )
+
+        placed = place_media_embeds(
+            "Before the figure.\n\nAfter the figure.\n", document, {0: _media("asset_img1.png")}, "doc"
+        )
+
+        assert placed == "Before the figure.\n\n![[doc/asset_img1.png]]\n\nAfter the figure.\n"
+
+    def test_image_inside_a_rendered_block_follows_it(self):
+        document = _document(
+            [
+                _block("paragraph", [_text("See"), _image(0, alt="the chart")]),
+                _block("paragraph", [_text("Tail.")]),
+            ]
+        )
+
+        placed = place_media_embeds("See the chart\n\nTail.\n", document, {0: _media("asset_img1.png")}, "doc")
+
+        assert placed == "See the chart\n\n![[doc/asset_img1.png]]\n\nTail.\n"
+
+    def test_image_in_a_table_cell_follows_the_table(self):
+        cell = SimpleNamespace(kind="origin", cell=SimpleNamespace(blocks=[_block("paragraph", [_image(0)])]))
+        header = SimpleNamespace(kind="origin", cell=SimpleNamespace(blocks=[_block("paragraph", [_text("h")])]))
+        table = _block("table", None, table=SimpleNamespace(grid=[[header], [cell]], header_rows=1, kind="data"))
+        document = _document([table, _block("paragraph", [_text("Tail.")])])
+        markdown = "| h |\n| --- |\n|  |\n\nTail.\n"
+
+        placed = place_media_embeds(markdown, document, {0: _media("asset_img1.png")}, "doc")
+
+        assert placed == "| h |\n| --- |\n|  |\n\n![[doc/asset_img1.png]]\n\nTail.\n"
+
+    def test_trailing_image_block_lands_after_the_last_block(self):
+        document = _document([_block("paragraph", [_text("Body.")]), _block("paragraph", [_image(0)])])
+
+        placed = place_media_embeds("Body.\n", document, {0: _media("asset_img1.png")}, "doc")
+
+        assert placed == "Body.\n\n![[doc/asset_img1.png]]\n"
+
+    def test_several_images_in_one_block_keep_their_order(self):
+        document = _document([_block("paragraph", [_image(0), _image(1)]), _block("paragraph", [_text("Tail.")])])
+        media = {0: _media("asset_img1.png"), 1: _media("asset_img2.png")}
+
+        placed = place_media_embeds("Tail.\n", document, media, "doc")
+
+        assert placed == "![[doc/asset_img1.png]]\n![[doc/asset_img2.png]]\n\nTail.\n"
+
+    def test_rule_block_does_not_shift_placement(self):
+        document = _document(
+            [
+                _block("paragraph", [_text("Above.")]),
+                _block("rule"),
+                _block("paragraph", [_image(0)]),
+                _block("paragraph", [_text("Below.")]),
+            ]
+        )
+
+        placed = place_media_embeds("Above.\n\n---\n\nBelow.\n", document, {0: _media("asset_img1.png")}, "doc")
+
+        assert placed == "Above.\n\n---\n\n![[doc/asset_img1.png]]\n\nBelow.\n"
+
+    def test_misaligned_markdown_leaves_the_text_untouched(self):
+        # The markdown does not match the model, so no position can be trusted:
+        # the embed is left to extract_file, which appends it.
+        document = _document(
+            [
+                _block("paragraph", [_text("Text the markdown does not contain")]),
+                _block("paragraph", [_image(0)]),
+            ]
+        )
+
+        placed = place_media_embeds("Entirely different output\n", document, {0: _media("asset_img1.png")}, "doc")
+
+        assert placed == "Entirely different output\n"
+
+    def test_image_in_a_list_item_follows_the_list(self):
+        item = SimpleNamespace(blocks=[_block("paragraph", [_text("Item one"), _image(0)])])
+        listing = _block("list", None, list=SimpleNamespace(marker="bullet", start=1, items=[item]))
+        document = _document([listing, _block("paragraph", [_text("Tail.")])])
+
+        placed = place_media_embeds("- Item one\n\nTail.\n", document, {0: _media("asset_img1.png")}, "doc")
+
+        assert placed == "- Item one\n\n![[doc/asset_img1.png]]\n\nTail.\n"
+
+    def test_image_in_a_block_quote_follows_the_quote(self):
+        quote = _block("block_quote", None, blocks=[_block("paragraph", [_text("Quoted"), _image(0)])])
+        document = _document([quote, _block("paragraph", [_text("Tail.")])])
+
+        placed = place_media_embeds("> Quoted\n\nTail.\n", document, {0: _media("asset_img1.png")}, "doc")
+
+        assert placed == "> Quoted\n\n![[doc/asset_img1.png]]\n\nTail.\n"
+
+    def test_code_block_and_link_keep_alignment(self):
+        link = SimpleNamespace(
+            kind="link",
+            text=None,
+            alt=None,
+            content=[_text("the docs")],
+            source=None,
+            target=SimpleNamespace(kind="external", value="https://example.com"),
+        )
+        document = _document(
+            [
+                _block("code_block", None, lang="python", text="value = 1"),
+                _block("paragraph", [_text("Read"), link]),
+                _block("paragraph", [_image(0)]),
+                _block("paragraph", [_text("Tail.")]),
+            ]
+        )
+        markdown = "```python\nvalue = 1\n```\n\nRead [the docs](https://example.com)\n\nTail.\n"
+
+        placed = place_media_embeds(markdown, document, {0: _media("asset_img1.png")}, "doc")
+
+        assert placed == (
+            "```python\nvalue = 1\n```\n\nRead [the docs](https://example.com)\n\n![[doc/asset_img1.png]]\n\nTail.\n"
+        )
+
+    def test_external_image_is_left_to_anydoc(self):
+        external = SimpleNamespace(
+            kind="image",
+            text=None,
+            alt="remote",
+            content=None,
+            source=SimpleNamespace(kind="external", asset_id=None, url="https://example.com/i.png"),
+        )
+        document = _document([_block("paragraph", [external]), _block("paragraph", [_text("Tail.")])])
+        markdown = "![remote](https://example.com/i.png)\n\nTail.\n"
+
+        placed = place_media_embeds(markdown, document, {0: _media("asset_img1.png")}, "doc")
+
+        assert placed == markdown
+
+    def test_asset_without_a_media_file_is_skipped(self):
+        document = _document([_block("paragraph", [_image(7)]), _block("paragraph", [_text("Tail.")])])
+
+        placed = place_media_embeds("Tail.\n", document, {}, "doc")
+
+        assert placed == "Tail.\n"
+
+    @given(
+        image_positions=st.lists(st.booleans(), min_size=1, max_size=8),
+    )
+    def test_every_image_is_embedded_exactly_once(self, image_positions):
+        # A document of paragraphs, some of which are image-only blocks.
+        blocks: list = []
+        paragraphs: list[str] = []
+        media: dict[int, MediaFile] = {}
+        for index, is_image in enumerate(image_positions):
+            if is_image:
+                blocks.append(_block("paragraph", [_image(index)]))
+                media[index] = _media(f"asset_img{index}.png")
+            else:
+                text = f"paragraph number {index}"
+                blocks.append(_block("paragraph", [_text(text)]))
+                paragraphs.append(text)
+        markdown = "\n\n".join(paragraphs) + "\n" if paragraphs else ""
+
+        placed = place_media_embeds(markdown, _document(blocks), media, "doc")
+
+        assert placed.count("![[") == len(media)
+        for media_file in media.values():
+            assert placed.count(f"![[doc/{media_file.filename}]]") == 1
+        for text in paragraphs:
+            assert text in placed

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -20,6 +20,23 @@ class TestDoctorCommand:
         assert "native (docx)" in result.output
         assert "native (xlsx)" in result.output
 
+    def test_doctor_reports_anydoc(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor"])
+        assert "anydoc" in result.output
+        assert "[OK]" in result.output
+
+    def test_doctor_missing_anydoc_exits_1(self):
+        runner = CliRunner()
+
+        def fake_check(backend, extension):
+            return (False, "not found") if backend == "anydoc" else (True, "ok")
+
+        with patch("obsidian_import.cli.check_backend_available", side_effect=fake_check):
+            result = runner.invoke(main, ["doctor"])
+        assert result.exit_code == 1
+        assert "Some required backends are missing" in result.output
+
     def test_doctor_native_unavailable_exits_1(self):
         runner = CliRunner()
         with patch(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,12 +66,17 @@ class TestDefaultConfig:
 
     def test_default_document_backends_are_anydoc(self):
         config = default_config()
-        assert config.backends.pdf == "anydoc"
         assert config.backends.docx == "anydoc"
         assert config.backends.pptx == "anydoc"
         assert config.backends.xlsx == "anydoc"
         assert config.backends.csv == "anydoc"
         assert config.backends.default == "anydoc"
+
+    def test_default_pdf_backend_is_native(self):
+        # anydoc has no document model for PDF, so the native backend is the
+        # default there: it keeps page headings, page_count, and page images.
+        config = default_config()
+        assert config.backends.pdf == "native"
 
     def test_formats_anydoc_cannot_read_stay_native(self):
         # anydoc reads document formats only: JSON, YAML, and images have no

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,13 +64,19 @@ class TestDefaultConfig:
         config = default_config()
         assert isinstance(config, ImportConfig)
 
-    def test_default_backends_are_native(self):
+    def test_default_document_backends_are_anydoc(self):
         config = default_config()
-        assert config.backends.pdf == "native"
-        assert config.backends.docx == "native"
-        assert config.backends.pptx == "native"
-        assert config.backends.xlsx == "native"
-        assert config.backends.csv == "native"
+        assert config.backends.pdf == "anydoc"
+        assert config.backends.docx == "anydoc"
+        assert config.backends.pptx == "anydoc"
+        assert config.backends.xlsx == "anydoc"
+        assert config.backends.csv == "anydoc"
+        assert config.backends.default == "anydoc"
+
+    def test_formats_anydoc_cannot_read_stay_native(self):
+        # anydoc reads document formats only: JSON, YAML, and images have no
+        # anydoc parser, so those keys keep the native backends.
+        config = default_config()
         assert config.backends.json == "native"
         assert config.backends.yaml == "native"
         assert config.backends.image == "native"
@@ -445,11 +451,11 @@ backends:
         assert config.backends.image == "markitdown"
         assert config.backends.html == "native"
 
-    def test_new_backend_keys_default_to_native(self, tmp_path):
+    def test_new_backend_keys_take_bundled_defaults(self, tmp_path):
         config_file = tmp_path / "config.yaml"
         config_file.write_text("")
         config = load_config(config_file)
-        assert config.backends.csv == "native"
+        assert config.backends.csv == "anydoc"
         assert config.backends.json == "native"
         assert config.backends.yaml == "native"
         assert config.backends.image == "native"

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -37,7 +37,7 @@ class TestConfigFromOverrides:
     def test_backend_override(self) -> None:
         config = config_from_overrides({"backends": {"pdf": "markitdown"}})
         assert config.backends.pdf == "markitdown"
-        assert config.backends.docx == "native"
+        assert config.backends.docx == "anydoc"
 
     def test_invalid_overrides_raise_config_error(self) -> None:
         with pytest.raises(ConfigError):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -42,6 +42,21 @@ def _native_backends() -> BackendsConfig:
     )
 
 
+def _anydoc_backends() -> BackendsConfig:
+    return BackendsConfig(
+        pdf="anydoc",
+        docx="anydoc",
+        pptx="anydoc",
+        xlsx="anydoc",
+        csv="anydoc",
+        json="native",
+        yaml="native",
+        image="native",
+        html="markitdown",
+        default="anydoc",
+    )
+
+
 class TestGetBackendModule:
     def test_pdf_returns_native_pdf(self):
         module = get_backend_module(".pdf", _native_backends())
@@ -156,6 +171,18 @@ class TestGetBackendModule:
         with pytest.raises(UnsupportedFormatError, match="Unknown backend"):
             get_backend_module(".pdf", backends)
 
+    @pytest.mark.parametrize("extension", [".pdf", ".docx", ".pptx", ".xlsx", ".csv"])
+    def test_anydoc_serves_every_document_extension(self, extension):
+        module = get_backend_module(extension, _anydoc_backends())
+        assert module.__name__ == "obsidian_import.backends.anydoc"
+
+    @pytest.mark.parametrize("extension", [".rtf", ".epub", ".odt", ".doc", ".xls", ".ppt"])
+    def test_unregistered_extensions_reach_anydoc_via_default(self, extension):
+        # anydoc reads these formats and no config key names them, so the
+        # `default` backend is what makes them convertible.
+        module = get_backend_module(extension, _anydoc_backends())
+        assert module.__name__ == "obsidian_import.backends.anydoc"
+
 
 class TestExtractWithBackend:
     def _markitdown_backends(self) -> BackendsConfig:
@@ -196,6 +223,32 @@ class TestExtractWithBackend:
 
         assert result.markdown == "extracted"
         assert any("max_rows_per_sheet" in r.message for r in caplog.records)
+
+    def test_unsupported_kwarg_warns_once_per_configuration(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A batch run must report a capability gap once, not once per file."""
+        fake_module = types.ModuleType("obsidian_import.backends.markitdown")
+        fake_module.extract = lambda path, timeout_seconds: "extracted"  # type: ignore[attr-defined]
+
+        import logging
+
+        ctx = ExtractionContext(
+            backends=self._markitdown_backends(),
+            timeout_seconds=30,
+            media_config=_TEST_MEDIA_CONFIG,
+            isolation="thread",
+        )
+        with (
+            patch("obsidian_import.registry.get_backend_module", return_value=fake_module),
+            caplog.at_level(logging.WARNING, logger="obsidian_import.registry"),
+        ):
+            for name in ("one.xlsx", "two.xlsx", "three.xlsx"):
+                sheet = tmp_path / name
+                sheet.write_bytes(b"fake")
+                extract_with_backend(sheet, ctx, max_rows_per_sheet=100)
+
+        assert sum("max_rows_per_sheet" in r.message for r in caplog.records) == 1
 
     def test_supported_kwarg_is_forwarded(self, tmp_path: Path) -> None:
         """max_rows_per_sheet must be forwarded when the backend accepts it."""
@@ -243,6 +296,11 @@ class TestCheckBackendAvailable:
     def test_native_pdf_available(self):
         available, message = check_backend_available("native", ".pdf")
         assert available is True
+
+    def test_anydoc_available(self):
+        available, message = check_backend_available("anydoc", ".pdf")
+        assert available is True
+        assert "anydoc backend available" in message
 
     def test_native_unknown_extension(self):
         available, message = check_backend_available("native", ".xyz")


### PR DESCRIPTION
Closes #297.

## Why

Document conversion was split across hand-rolled native backends, none of which read legacy Office, OpenDocument, RTF, or EPUB at all. [anydoc](https://github.com/firecrawl/anydoc) converts all of them, benchmarks well against markitdown/docling/pandoc, and ships as a compiled Rust wheel — no model downloads, no extra install step — so it becomes a required dependency and the default converter rather than an opt-in extra.

## What changed

**New `anydoc` backend** (`obsidian_import/backends/anydoc.py`). Detects the format from content, with the extension as fallback for signature-less input; converts through `to_markdown_bytes`; recovers embedded images from the document model. `ConvertError` is translated to `ExtractionError` naming the detected format and pointing at the `backends` config; timeout and isolation go through the shared `TimeoutContext`.

**Defaults** now route `docx`, `pptx`, `xlsx`, `csv`, and `default` to anydoc. `default: anydoc` is what makes `.doc`, `.xls`, `.ppt`, `.odt`, `.ods`, `.odp`, `.rtf`, and `.epub` convert with no configuration. JSON, YAML, and images keep the native backends; HTML keeps markitdown.

**PDF deliberately stays on `native`.** anydoc exposes no document model for PDF, which costs three things at once: embedded page images, the `## Page N` headings, and the `page_count` frontmatter derived from them. It also has no OCR, so a scanned PDF would fail instead of yielding an empty note. `pdf: anydoc` remains available and tested for anyone who prefers anydoc's PDF text.

**Inline image embeds** (`obsidian_import/anydoc_placement.py`). anydoc renders an embedded image as its alt text — or as nothing when it has none — and upstream has no option to emit an image reference, so there is nothing in its Markdown to rewrite into a wikilink. What the Markdown and the document model do share is block order. Placement walks the two sequences in step: a block that renders text consumes the next Markdown block and its images are embedded after it; a block that renders nothing has its images embedded at that position. Each consumed pair is verified against the block's own text (compared on alphanumerics, so anydoc's `##`, `-`, `|`, and escapes do not interfere), and alignment stops at the first mismatch rather than guessing — leftovers fall back to `extract_file`'s existing append. Embeds are inserted at character offsets, so anydoc's text is interleaved, never rewritten. Images inside table cells, list items, and block quotes are embedded after the container that holds them, the finest position the Markdown exposes.

Real output, images where they sat in the source document (the middle one lives in a table cell):

```markdown
# Report Title

Intro paragraph with some text.

[[rich/asset_img1.png]]

After the first figure.

## Findings

- First bullet
- Second bullet

| H1 | H2 |
| --- | --- |
| a | b |

[[rich/asset_img2.png]]

Closing paragraph.

[[rich/asset_img3.png]]
```

**Capability-warning fix.** Making anydoc the default put `extract_with_backend`'s "backend does not support &lt;option&gt;" warning on the happy path — once per file for `max_file_size_mb` on every `.docx` and `max_rows_per_sheet` on every `.xlsx`. A gap is a property of the configuration, not of the file, so the registry now reports each one once per (backend, extension, options); `reset_capability_gap_warnings()` keeps it independent of test order.

## Trade-offs worth reviewing

- `extraction.xlsx_max_rows_per_sheet` does not apply to anydoc. It is reported as ignored for `.xlsx`; `xlsx: native` caps rows per sheet. Documented in `default.yaml`, the README, and the backends guide.
- Block alignment is a contract with anydoc's renderer that upstream does not publish. If a future version changes block spacing, the verification step catches it and placement degrades to appending — it cannot silently misplace an image, but inline behavior would stop. Worth a review when bumping past the current `>=0.1.6,<0.2` pin.

## Verification

- `pixi run test-cov`: **549 passed**, 99% total coverage; `anydoc.py` and `anydoc_placement.py` both at 100%.
- `pixi run lint`, `pixi run format-check`, `pixi run docs-build`: clean.
- Suite re-run under randomized test ordering (two seeds) to confirm the new module-level warning memo and autouse fixture keep tests order-independent.
- Backend tests run real anydoc conversions against synthetic DOCX/CSV/PDF fixtures rather than mocking the converter, plus hypothesis properties for CSV row preservation, block-span reconstruction, and one-embed-per-image.
- End-to-end CLI check confirms media files land in the note's media folder alongside the inline wikilinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eB3yVf7LiV6wC8YYePF54

---
_Generated by [Claude Code](https://claude.ai/code/session_017eB3yVf7LiV6wC8YYePF54)_